### PR TITLE
docs: GCPインフラ構成図を追加

### DIFF
--- a/docs/diagrams/aws-architecture.drawio.svg
+++ b/docs/diagrams/aws-architecture.drawio.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1200" height="920" viewBox="-0.5 -0.5 1200 920" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;&lt;diagram name=&quot;AWS Architecture&quot; id=&quot;aws-arch&quot;&gt;&lt;mxGraphModel dx=&quot;1200&quot; dy=&quot;920&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1200&quot; pageHeight=&quot;920&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;mxCell id=&quot;title&quot; value=&quot;AWS Infrastructure Architecture&quot; style=&quot;text;html=1;fontSize=20;fontStyle=1;fillColor=none;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;350&quot; y=&quot;10&quot; width=&quot;500&quot; height=&quot;30&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;user&quot; value=&quot;User&quot; style=&quot;shape=actor;whiteSpace=wrap;html=1;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;560&quot; y=&quot;50&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;auth0&quot; value=&quot;Auth0&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f0f0f0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;950&quot; y=&quot;55&quot; width=&quot;120&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cf&quot; value=&quot;CloudFront&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;490&quot; y=&quot;130&quot; width=&quot;180&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;s3&quot; value=&quot;S3 Bucket (React SPA)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;100&quot; y=&quot;240&quot; width=&quot;180&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;vpc&quot; value=&quot;VPC 172.16.0.0/16&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;verticalAlign=top;fontSize=12;fontStyle=1;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;350&quot; y=&quot;230&quot; width=&quot;800&quot; height=&quot;540&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;pub_sub&quot; value=&quot;Public Subnet 172.16.1.0/24 (ap-northeast-1a)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;verticalAlign=top;fontSize=11;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;370&quot; y=&quot;260&quot; width=&quot;340&quot; height=&quot;130&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;priv_sub&quot; value=&quot;Private Subnets 172.16.2.0/24 (1a) &amp;amp; 172.16.3.0/24 (1c)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;verticalAlign=top;fontSize=11;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;370&quot; y=&quot;410&quot; width=&quot;760&quot; height=&quot;340&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;nat&quot; value=&quot;NAT Gateway&amp;#xa;(EIP)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;400&quot; y=&quot;300&quot; width=&quot;100&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;igw&quot; value=&quot;Internet&amp;#xa;Gateway&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;520&quot; y=&quot;300&quot; width=&quot;100&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;bastion&quot; value=&quot;Bastion&amp;#xa;Host (EC2)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;640&quot; y=&quot;300&quot; width=&quot;100&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;alb&quot; value=&quot;ALB (Internal)&amp;#xa;HTTP:80&amp;#xa;Rule: /api/*&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;510&quot; y=&quot;450&quot; width=&quot;140&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;ecs&quot; value=&quot;ECS Fargate&amp;#xa;CPU:256 / Mem:512MB&amp;#xa;NestJS API (:3000)&amp;#xa;Docker Image from ECR&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;490&quot; y=&quot;550&quot; width=&quot;180&quot; height=&quot;80&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aurora&quot; value=&quot;Aurora Serverless v2&amp;#xa;PostgreSQL 16.6&amp;#xa;0.0-1.0 ACU&amp;#xa;Encrypted&quot; style=&quot;shape=cylinder3;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;size=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;810&quot; y=&quot;535&quot; width=&quot;150&quot; height=&quot;100&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;ecr&quot; value=&quot;ECR&amp;#xa;Container&amp;#xa;Registry&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;810&quot; y=&quot;450&quot; width=&quot;100&quot; height=&quot;55&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;ssm&quot; value=&quot;SSM Parameter Store&amp;#xa;(SecureString)&amp;#xa;DB Connection&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;390&quot; y=&quot;660&quot; width=&quot;140&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cw&quot; value=&quot;CloudWatch Logs&amp;#xa;(Retention: 7d)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;560&quot; y=&quot;660&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;vpce&quot; value=&quot;VPC Endpoints&amp;#xa;(SSM, ECR, Logs)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;980&quot; y=&quot;450&quot; width=&quot;130&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cp_be&quot; value=&quot;CodePipeline&amp;#xa;(Backend)&amp;#xa;Source→Build→Deploy&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;460&quot; width=&quot;140&quot; height=&quot;60&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cp_fe&quot; value=&quot;CodePipeline&amp;#xa;(Frontend)&amp;#xa;Source→Build&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;370&quot; width=&quot;140&quot; height=&quot;55&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;github&quot; value=&quot;GitHub&amp;#xa;(CodeStar Connection)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#333333;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;560&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;sg_label&quot; value=&quot;Security Groups:&amp;#xa;CF VPC Origin SG → ALB SG → ECS SG → DB SG&amp;#xa;Bastion SG → DB SG&quot; style=&quot;text;html=1;fontSize=10;fillColor=none;align=left;verticalAlign=top;whiteSpace=wrap;rounded=1;strokeColor=#999999;dashed=1;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;830&quot; width=&quot;400&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;region_label&quot; value=&quot;Region: ap-northeast-1&quot; style=&quot;text;html=1;fontSize=11;fillColor=none;align=left;fontStyle=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;890&quot; width=&quot;200&quot; height=&quot;20&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e1&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;&quot; edge=&quot;1&quot; source=&quot;user&quot; target=&quot;cf&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e1l&quot; value=&quot;HTTPS&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e1&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e2&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;&quot; edge=&quot;1&quot; source=&quot;cf&quot; target=&quot;s3&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e2l&quot; value=&quot;/* (OAC)&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e2&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e3&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;&quot; edge=&quot;1&quot; source=&quot;cf&quot; target=&quot;alb&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e3l&quot; value=&quot;/api/* (VPC Origin)&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e3&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e4&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;&quot; edge=&quot;1&quot; source=&quot;alb&quot; target=&quot;ecs&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e4l&quot; value=&quot;:3000&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e4&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e5&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;&quot; edge=&quot;1&quot; source=&quot;ecs&quot; target=&quot;aurora&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e5l&quot; value=&quot;:5432 (SSL)&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e5&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e6&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;ecr&quot; target=&quot;ecs&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e6l&quot; value=&quot;image pull&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e6&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e7&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;bastion&quot; target=&quot;aurora&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e7l&quot; value=&quot;:5432&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e7&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e8&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;ecs&quot; target=&quot;ssm&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e8l&quot; value=&quot;secrets&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e8&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e9&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;ecs&quot; target=&quot;cw&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e9l&quot; value=&quot;logs&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e9&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e10&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;user&quot; target=&quot;auth0&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e10l&quot; value=&quot;OAuth2 / JWT&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e10&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e11&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;cp_fe&quot; target=&quot;s3&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e11l&quot; value=&quot;deploy dist/&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e11&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e12&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;cp_be&quot; target=&quot;ecr&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e12l&quot; value=&quot;docker push&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e12&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e13&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;github&quot; target=&quot;cp_be&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e14&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;github&quot; target=&quot;cp_fe&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e15&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;cp_be&quot; target=&quot;ecs&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;&gt;&lt;Array as=&quot;points&quot;&gt;&lt;mxPoint x=&quot;250&quot; y=&quot;490&quot;/&gt;&lt;mxPoint x=&quot;250&quot; y=&quot;590&quot;/&gt;&lt;/Array&gt;&lt;/mxGeometry&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e15l&quot; value=&quot;ECS deploy&quot; style=&quot;edgeLabel;html=1;fontSize=9;&quot; vertex=&quot;1&quot; connectable=&quot;0&quot; parent=&quot;e15&quot;&gt;&lt;mxGeometry x=&quot;-0.2&quot; relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1200" height="920" viewBox="-0.5 -0.5 1200 920" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;&lt;diagram name=&quot;AWS Architecture&quot; id=&quot;aws-arch&quot;&gt;&lt;mxGraphModel dx=&quot;1200&quot; dy=&quot;920&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1200&quot; pageHeight=&quot;920&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;mxCell id=&quot;title&quot; value=&quot;AWS Infrastructure Architecture&quot; style=&quot;text;html=1;fontSize=20;fontStyle=1;fillColor=none;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;350&quot; y=&quot;10&quot; width=&quot;500&quot; height=&quot;30&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;user&quot; value=&quot;User&quot; style=&quot;shape=mxgraph.aws4.client;whiteSpace=wrap;html=1;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;555&quot; y=&quot;50&quot; width=&quot;50&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;auth0&quot; value=&quot;Auth0&amp;#xa;JWT / OAuth2 / JWKS&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f0f0f0;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;930&quot; y=&quot;50&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cf&quot; value=&quot;CloudFront&amp;#xa;CDN / HTTPS / SPA Error Handling&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudfront;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;556&quot; y=&quot;130&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;s3&quot; value=&quot;S3 Bucket&amp;#xa;React SPA (Static Files)&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#277116;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;146&quot; y=&quot;240&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;vpc&quot; value=&quot;VPC 172.16.0.0/16&quot; style=&quot;points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=1;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_vpc;strokeColor=#248814;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#AAB7B8;dashed=0;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;350&quot; y=&quot;230&quot; width=&quot;800&quot; height=&quot;540&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;pub_sub&quot; value=&quot;Public Subnet 172.16.1.0/24 (ap-northeast-1a)&quot; style=&quot;points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=11;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_subnet;strokeColor=#248814;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#AAB7B8;dashed=0;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;30&quot; width=&quot;380&quot; height=&quot;140&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;priv_sub&quot; value=&quot;Private Subnets 172.16.2.0/24 (1a) &amp;amp; 172.16.3.0/24 (1c)&quot; style=&quot;points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=11;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_subnet;strokeColor=#147EBA;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#AAB7B8;dashed=0;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;190&quot; width=&quot;760&quot; height=&quot;330&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;nat&quot; value=&quot;NAT Gateway&amp;#xa;(Elastic IP)&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.nat_gateway;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;40&quot; y=&quot;70&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;igw&quot; value=&quot;Internet&amp;#xa;Gateway&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.internet_gateway;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;160&quot; y=&quot;70&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;bastion&quot; value=&quot;Bastion Host&amp;#xa;(EC2)&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ec2;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;300&quot; y=&quot;70&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;alb&quot; value=&quot;ALB (Internal)&amp;#xa;HTTP:80 / Rule: /api/*&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.elastic_load_balancing;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;180&quot; y=&quot;230&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;ecs&quot; value=&quot;ECS Fargate&amp;#xa;CPU:256 / Mem:512MB&amp;#xa;NestJS API (:3000)&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecs;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;170&quot; y=&quot;340&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aurora&quot; value=&quot;Aurora Serverless v2&amp;#xa;PostgreSQL 16.6&amp;#xa;0.0-1.0 ACU / Encrypted&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C925D1;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.aurora;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;480&quot; y=&quot;330&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;ecr&quot; value=&quot;ECR&amp;#xa;Container Registry&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecr;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;480&quot; y=&quot;230&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;ssm&quot; value=&quot;SSM Parameter Store&amp;#xa;SecureString (DB URL)&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.systems_manager;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;40&quot; y=&quot;440&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cw&quot; value=&quot;CloudWatch Logs&amp;#xa;Retention: 7 days&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;220&quot; y=&quot;440&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;vpce&quot; value=&quot;VPC Endpoints&amp;#xa;(SSM, ECR, Logs)&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.endpoint;&quot; vertex=&quot;1&quot; parent=&quot;vpc&quot;&gt;&lt;mxGeometry x=&quot;630&quot; y=&quot;230&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cp_be&quot; value=&quot;CodePipeline (Backend)&amp;#xa;Source&#8594;Build&#8594;Deploy&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C7131F;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.codepipeline;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;55&quot; y=&quot;460&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cp_fe&quot; value=&quot;CodePipeline (Frontend)&amp;#xa;Source&#8594;Build&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C7131F;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.codepipeline;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;55&quot; y=&quot;360&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;github&quot; value=&quot;GitHub&amp;#xa;(CodeStar Connection)&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#24292E;fontColor=#FFFFFF;strokeColor=#24292E;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;560&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;sg_label&quot; value=&quot;Security Groups: CF VPC Origin SG &#8594; ALB SG (HTTP:80) &#8594; ECS SG (:3000) &#8594; DB SG (:5432) / Bastion SG &#8594; DB SG&quot; style=&quot;text;html=1;fontSize=10;fillColor=none;align=left;verticalAlign=top;whiteSpace=wrap;rounded=1;strokeColor=#999999;dashed=1;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;840&quot; width=&quot;550&quot; height=&quot;30&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;region_label&quot; value=&quot;Region: ap-northeast-1 (Tokyo)&quot; style=&quot;text;html=1;fontSize=11;fillColor=none;align=left;fontStyle=2;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;20&quot; y=&quot;880&quot; width=&quot;250&quot; height=&quot;20&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e1&quot; value=&quot;HTTPS&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;user&quot; target=&quot;cf&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e2&quot; value=&quot;/* (OAC SigV4)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;cf&quot; target=&quot;s3&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e3&quot; value=&quot;/api/* (VPC Origin)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;cf&quot; target=&quot;alb&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e4&quot; value=&quot;:3000&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;alb&quot; target=&quot;ecs&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e5&quot; value=&quot;:5432 (SSL)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;ecs&quot; target=&quot;aurora&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e6&quot; value=&quot;image pull&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;ecr&quot; target=&quot;ecs&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e7&quot; value=&quot;:5432 (admin)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;bastion&quot; target=&quot;aurora&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e8&quot; value=&quot;secrets&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;ecs&quot; target=&quot;ssm&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e9&quot; value=&quot;logs&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;ecs&quot; target=&quot;cw&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e10&quot; value=&quot;OAuth2 / JWT (RS256)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;user&quot; target=&quot;auth0&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e11&quot; value=&quot;deploy dist/&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;cp_fe&quot; target=&quot;s3&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e12&quot; value=&quot;docker push&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;cp_be&quot; target=&quot;ecr&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e13&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;github&quot; target=&quot;cp_be&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e14&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;&quot; edge=&quot;1&quot; source=&quot;github&quot; target=&quot;cp_fe&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e15&quot; value=&quot;ECS deploy&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;cp_be&quot; target=&quot;ecs&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;&gt;&lt;Array as=&quot;points&quot;&gt;&lt;mxPoint x=&quot;250&quot; y=&quot;490&quot;/&gt;&lt;mxPoint x=&quot;250&quot; y=&quot;700&quot;/&gt;&lt;/Array&gt;&lt;/mxGeometry&gt;&lt;/mxCell&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
   <defs/>
   <g>
     <!-- Title -->
@@ -26,186 +26,244 @@
     <polygon points="916,62 922,65 916,68" fill="#999999"/>
     <text x="760" y="58" fill="#999999" font-family="Helvetica" font-size="9" text-anchor="middle">OAuth2 / JWT (RS256)</text>
 
-    <!-- CloudFront -->
-    <rect x="460" y="130" width="240" height="55" rx="10" fill="#D5E8D4" stroke="#82B366" stroke-width="2"/>
-    <text x="580" y="152" fill="#333333" font-family="Helvetica" font-size="14" text-anchor="middle" font-weight="bold">CloudFront</text>
-    <text x="580" y="172" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">CDN / HTTPS Redirect / SPA Error Handling</text>
+    <!-- CloudFront icon -->
+    <g transform="translate(556,130)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#8C4FFF" stroke="none"/>
+      <text x="24" y="20" fill="#FFFFFF" font-family="Helvetica" font-size="8" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="24" y="32" fill="#FFFFFF" font-family="Helvetica" font-size="8" text-anchor="middle" font-weight="bold">Front</text>
+    </g>
+    <text x="580" y="193" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">CloudFront</text>
+    <text x="580" y="207" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">CDN / HTTPS / SPA Error Handling</text>
 
     <!-- User to CloudFront arrow -->
     <line x1="580" y1="115" x2="580" y2="130" stroke="#333333" stroke-width="2"/>
     <polygon points="576,127 580,133 584,127" fill="#333333"/>
     <text x="595" y="124" fill="#333333" font-family="Helvetica" font-size="9">HTTPS</text>
 
-    <!-- S3 -->
-    <rect x="70" y="230" width="200" height="55" rx="10" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="2"/>
-    <text x="170" y="252" fill="#333333" font-family="Helvetica" font-size="13" text-anchor="middle" font-weight="bold">S3 Bucket</text>
-    <text x="170" y="270" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">React SPA (Static Files)</text>
+    <!-- S3 icon -->
+    <g transform="translate(146,240)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#277116" stroke="none"/>
+      <text x="24" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="14" text-anchor="middle" font-weight="bold">S3</text>
+    </g>
+    <text x="170" y="303" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">S3 Bucket</text>
+    <text x="170" y="317" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">React SPA (Static Files)</text>
 
     <!-- CloudFront to S3 arrow -->
-    <path d="M 460,165 L 320,165 L 320,255 L 270,255" fill="none" stroke="#333333" stroke-width="1.5"/>
-    <polygon points="274,252 268,255 274,258" fill="#333333"/>
-    <text x="340" y="158" fill="#333333" font-family="Helvetica" font-size="9">/* (OAC SigV4)</text>
+    <path d="M 556,154 L 320,154 L 320,264 L 194,264" fill="none" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="198,261 192,264 198,267" fill="#333333"/>
+    <text x="340" y="148" fill="#333333" font-family="Helvetica" font-size="9">/* (OAC SigV4)</text>
 
     <!-- VPC Box -->
-    <rect x="340" y="220" width="830" height="580" rx="12" fill="none" stroke="#D6B656" stroke-width="2.5" stroke-dasharray="8,4"/>
-    <rect x="350" y="220" width="200" height="22" rx="4" fill="#FFF2CC" stroke="none"/>
-    <text x="360" y="236" fill="#8B7000" font-family="Helvetica" font-size="12" font-weight="bold">VPC 172.16.0.0/16</text>
+    <rect x="340" y="220" width="830" height="580" rx="12" fill="none" stroke="#248814" stroke-width="2.5"/>
+    <rect x="350" y="220" width="200" height="22" rx="4" fill="#E9F3E6" stroke="none"/>
+    <g transform="translate(352,222)">
+      <rect x="0" y="0" width="18" height="18" rx="2" fill="#248814" stroke="none"/>
+      <text x="9" y="13" fill="#FFFFFF" font-family="Helvetica" font-size="8" text-anchor="middle" font-weight="bold">VPC</text>
+    </g>
+    <text x="378" y="236" fill="#248814" font-family="Helvetica" font-size="12" font-weight="bold">VPC 172.16.0.0/16</text>
 
     <!-- Public Subnet -->
-    <rect x="370" y="260" width="360" height="140" rx="8" fill="none" stroke="#82B366" stroke-width="1.5" stroke-dasharray="5,3"/>
-    <text x="380" y="278" fill="#5B8C3E" font-family="Helvetica" font-size="10" font-weight="bold">Public Subnet 172.16.1.0/24 (ap-northeast-1a)</text>
+    <rect x="370" y="260" width="360" height="140" rx="8" fill="#E9F3E6" stroke="#248814" stroke-width="1.5" fill-opacity="0.3"/>
+    <text x="380" y="278" fill="#248814" font-family="Helvetica" font-size="10" font-weight="bold">Public Subnet 172.16.1.0/24 (ap-northeast-1a)</text>
 
-    <!-- NAT Gateway -->
-    <rect x="390" y="300" width="110" height="50" rx="6" fill="#D5E8D4" stroke="#82B366" stroke-width="1.5"/>
-    <text x="445" y="320" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">NAT Gateway</text>
-    <text x="445" y="338" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">(Elastic IP)</text>
+    <!-- NAT Gateway icon -->
+    <g transform="translate(390,300)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#8C4FFF" stroke="none"/>
+      <text x="22" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">NAT</text>
+      <text x="22" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">GW</text>
+    </g>
+    <text x="412" y="358" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle">NAT Gateway</text>
+    <text x="412" y="370" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">(Elastic IP)</text>
 
-    <!-- Internet Gateway -->
-    <rect x="520" y="300" width="110" height="50" rx="6" fill="#D5E8D4" stroke="#82B366" stroke-width="1.5"/>
-    <text x="575" y="320" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Internet GW</text>
-    <text x="575" y="338" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">(igw)</text>
+    <!-- Internet Gateway icon -->
+    <g transform="translate(520,300)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#8C4FFF" stroke="none"/>
+      <text x="22" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">IGW</text>
+      <text x="22" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">Internet</text>
+    </g>
+    <text x="542" y="358" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle">Internet GW</text>
 
-    <!-- Bastion -->
-    <rect x="650" y="300" width="110" height="50" rx="6" fill="#E1D5E7" stroke="#9673A6" stroke-width="1.5"/>
-    <text x="705" y="320" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Bastion Host</text>
-    <text x="705" y="338" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">(EC2)</text>
+    <!-- Bastion icon -->
+    <g transform="translate(650,300)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#ED7100" stroke="none"/>
+      <text x="22" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">EC2</text>
+      <text x="22" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">Bastion</text>
+    </g>
+    <text x="672" y="358" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle">Bastion Host</text>
+    <text x="672" y="370" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">(EC2)</text>
 
     <!-- Private Subnets -->
-    <rect x="370" y="420" width="780" height="360" rx="8" fill="none" stroke="#B85450" stroke-width="1.5" stroke-dasharray="5,3"/>
-    <text x="380" y="438" fill="#B85450" font-family="Helvetica" font-size="10" font-weight="bold">Private Subnets 172.16.2.0/24 (1a) &amp; 172.16.3.0/24 (1c)</text>
+    <rect x="370" y="420" width="780" height="360" rx="8" fill="#EBF2FA" stroke="#147EBA" stroke-width="1.5" fill-opacity="0.3"/>
+    <text x="380" y="438" fill="#147EBA" font-family="Helvetica" font-size="10" font-weight="bold">Private Subnets 172.16.2.0/24 (1a) &amp; 172.16.3.0/24 (1c)</text>
 
-    <!-- ALB -->
-    <rect x="490" y="460" width="160" height="65" rx="8" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="2"/>
-    <text x="570" y="480" fill="#333333" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">ALB (Internal)</text>
-    <text x="570" y="496" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">HTTP:80</text>
-    <text x="570" y="512" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">Rule: /api/* → ECS</text>
+    <!-- ALB icon -->
+    <g transform="translate(548,460)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#8C4FFF" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">ALB</text>
+      <text x="24" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">Internal</text>
+    </g>
+    <text x="572" y="523" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">ALB (Internal)</text>
+    <text x="572" y="537" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">HTTP:80 / Rule: /api/*</text>
 
     <!-- CloudFront to ALB arrow -->
-    <path d="M 640,185 L 750,185 L 750,400 L 570,400 L 570,460" fill="none" stroke="#333333" stroke-width="1.5"/>
-    <polygon points="567,456 570,462 573,456" fill="#333333"/>
+    <path d="M 604,154 L 750,154 L 750,400 L 572,400 L 572,460" fill="none" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="569,456 572,462 575,456" fill="#333333"/>
     <text x="765" y="300" fill="#333333" font-family="Helvetica" font-size="9" transform="rotate(90,765,300)">/api/* (VPC Origin)</text>
 
-    <!-- ECS Fargate -->
-    <rect x="470" y="560" width="200" height="90" rx="8" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="2"/>
-    <text x="570" y="582" fill="#333333" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">ECS Fargate</text>
-    <text x="570" y="598" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">CPU: 256 / Mem: 512MB</text>
-    <text x="570" y="614" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">NestJS API (:3000)</text>
-    <text x="570" y="630" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">Docker Image from ECR</text>
+    <!-- ECS Fargate icon -->
+    <g transform="translate(536,570)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#ED7100" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">ECS</text>
+      <text x="24" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">Fargate</text>
+    </g>
+    <text x="560" y="633" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">ECS Fargate</text>
+    <text x="560" y="647" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">CPU:256 / Mem:512MB</text>
+    <text x="560" y="661" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">NestJS API (:3000)</text>
 
     <!-- ALB to ECS arrow -->
-    <line x1="570" y1="525" x2="570" y2="560" stroke="#333333" stroke-width="1.5"/>
-    <polygon points="567,556 570,562 573,556" fill="#333333"/>
-    <text x="585" y="545" fill="#333333" font-family="Helvetica" font-size="9">:3000</text>
+    <line x1="572" y1="542" x2="560" y2="570" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="557,566 560,572 563,566" fill="#333333"/>
+    <text x="580" y="555" fill="#333333" font-family="Helvetica" font-size="9">:3000</text>
 
-    <!-- Aurora -->
-    <ellipse cx="885" cy="580" rx="80" ry="15" fill="#FFF2CC" stroke="#D6B656" stroke-width="2"/>
-    <rect x="805" y="580" width="160" height="70" fill="#FFF2CC" stroke="#D6B656" stroke-width="2"/>
-    <ellipse cx="885" cy="650" rx="80" ry="15" fill="#FFF2CC" stroke="#D6B656" stroke-width="2"/>
-    <line x1="805" y1="580" x2="805" y2="650" stroke="#D6B656" stroke-width="2"/>
-    <line x1="965" y1="580" x2="965" y2="650" stroke="#D6B656" stroke-width="2"/>
-    <text x="885" y="604" fill="#333333" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Aurora Serverless v2</text>
-    <text x="885" y="620" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">PostgreSQL 16.6</text>
-    <text x="885" y="636" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">0.0-1.0 ACU / Encrypted</text>
+    <!-- Aurora icon -->
+    <g transform="translate(855,560)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#C925D1" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Aurora</text>
+      <text x="24" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">PgSQL</text>
+    </g>
+    <text x="879" y="623" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Aurora Serverless v2</text>
+    <text x="879" y="637" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">PostgreSQL 16.6</text>
+    <text x="879" y="651" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">0.0-1.0 ACU / Encrypted</text>
 
     <!-- ECS to Aurora arrow -->
-    <line x1="670" y1="605" x2="805" y2="605" stroke="#333333" stroke-width="1.5"/>
-    <polygon points="801,602 807,605 801,608" fill="#333333"/>
-    <text x="735" y="598" fill="#333333" font-family="Helvetica" font-size="9">:5432 (SSL)</text>
+    <line x1="584" y1="594" x2="855" y2="584" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="851,581 857,584 851,587" fill="#333333"/>
+    <text x="720" y="582" fill="#333333" font-family="Helvetica" font-size="9">:5432 (SSL)</text>
 
     <!-- Bastion to Aurora arrow -->
-    <path d="M 705,350 L 705,410 L 885,410 L 885,565" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="882,561 885,567 888,561" fill="#999999"/>
-    <text x="800" y="405" fill="#999999" font-family="Helvetica" font-size="9">:5432 (admin)</text>
+    <path d="M 672,350 L 672,410 L 879,410 L 879,560" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="876,556 879,562 882,556" fill="#999999"/>
+    <text x="790" y="405" fill="#999999" font-family="Helvetica" font-size="9">:5432 (admin)</text>
 
-    <!-- ECR -->
-    <rect x="810" y="460" width="120" height="50" rx="6" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="1.5"/>
-    <text x="870" y="480" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">ECR</text>
-    <text x="870" y="496" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Container Registry</text>
+    <!-- ECR icon -->
+    <g transform="translate(835,460)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#ED7100" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="8" text-anchor="middle" font-weight="bold">ECR</text>
+      <text x="24" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">Registry</text>
+    </g>
+    <text x="859" y="523" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">ECR</text>
+    <text x="859" y="537" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Container Registry</text>
 
     <!-- ECR to ECS arrow -->
-    <path d="M 810,495 L 750,495 L 750,590 L 670,590" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="674,587 668,590 674,593" fill="#999999"/>
+    <path d="M 835,490 L 750,490 L 750,594 L 584,594" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="588,591 582,594 588,597" fill="#999999"/>
     <text x="763" y="545" fill="#999999" font-family="Helvetica" font-size="9">image pull</text>
 
-    <!-- SSM -->
-    <rect x="390" y="680" width="150" height="50" rx="6" fill="#F5F5F5" stroke="#999999" stroke-width="1.5"/>
-    <text x="465" y="700" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">SSM Parameter Store</text>
-    <text x="465" y="716" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">SecureString (DB URL)</text>
+    <!-- SSM icon -->
+    <g transform="translate(405,680)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#E7157B" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">SSM</text>
+      <text x="24" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">Params</text>
+    </g>
+    <text x="429" y="743" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">SSM Parameter Store</text>
+    <text x="429" y="756" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">SecureString (DB URL)</text>
 
     <!-- ECS to SSM arrow -->
-    <path d="M 520,650 L 480,650 L 480,680" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="477,676 480,682 483,676" fill="#999999"/>
-    <text x="475" y="665" fill="#999999" font-family="Helvetica" font-size="9">secrets</text>
+    <path d="M 536,600 L 450,600 L 450,680" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="447,676 450,682 453,676" fill="#999999"/>
+    <text x="475" y="640" fill="#999999" font-family="Helvetica" font-size="9">secrets</text>
 
-    <!-- CloudWatch -->
-    <rect x="570" y="680" width="150" height="50" rx="6" fill="#F5F5F5" stroke="#999999" stroke-width="1.5"/>
-    <text x="645" y="700" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">CloudWatch Logs</text>
-    <text x="645" y="716" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Retention: 7 days</text>
+    <!-- CloudWatch icon -->
+    <g transform="translate(605,680)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#E7157B" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="24" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Watch</text>
+    </g>
+    <text x="629" y="743" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">CloudWatch Logs</text>
+    <text x="629" y="756" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Retention: 7 days</text>
 
     <!-- ECS to CloudWatch arrow -->
-    <path d="M 600,650 L 630,650 L 630,680" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="627,676 630,682 633,676" fill="#999999"/>
-    <text x="640" y="665" fill="#999999" font-family="Helvetica" font-size="9">logs</text>
+    <path d="M 584,600 L 629,600 L 629,680" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="626,676 629,682 632,676" fill="#999999"/>
+    <text x="620" y="640" fill="#999999" font-family="Helvetica" font-size="9">logs</text>
 
-    <!-- VPC Endpoints -->
-    <rect x="980" y="460" width="140" height="50" rx="6" fill="#F5F5F5" stroke="#999999" stroke-width="1.5"/>
-    <text x="1050" y="480" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">VPC Endpoints</text>
-    <text x="1050" y="496" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">SSM, ECR, Logs</text>
+    <!-- VPC Endpoints icon -->
+    <g transform="translate(1010,460)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#8C4FFF" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">VPC</text>
+      <text x="24" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Endpt</text>
+    </g>
+    <text x="1034" y="523" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">VPC Endpoints</text>
+    <text x="1034" y="536" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">SSM, ECR, Logs</text>
 
     <!-- CI/CD Section -->
-    <rect x="15" y="340" width="170" height="300" rx="8" fill="none" stroke="#9673A6" stroke-width="1.5" stroke-dasharray="5,3"/>
-    <text x="100" y="358" fill="#9673A6" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">CI/CD</text>
+    <rect x="15" y="340" width="170" height="300" rx="8" fill="none" stroke="#C7131F" stroke-width="1.5" stroke-dasharray="5,3"/>
+    <text x="100" y="358" fill="#C7131F" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">CI/CD</text>
 
-    <!-- CodePipeline Frontend -->
-    <rect x="30" y="375" width="140" height="55" rx="6" fill="#E1D5E7" stroke="#9673A6" stroke-width="1.5"/>
-    <text x="100" y="395" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">CodePipeline</text>
-    <text x="100" y="410" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">(Frontend)</text>
-    <text x="100" y="422" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Source → Build</text>
+    <!-- CodePipeline Frontend icon -->
+    <g transform="translate(58,370)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#C7131F" stroke="none"/>
+      <text x="22" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Code</text>
+      <text x="22" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Pipeline</text>
+      <text x="22" y="38" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">(FE)</text>
+    </g>
+    <text x="80" y="428" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">CodePipeline</text>
+    <text x="80" y="440" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">(Frontend) Source&#x2192;Build</text>
 
-    <!-- CodePipeline Backend -->
-    <rect x="30" y="450" width="140" height="60" rx="6" fill="#E1D5E7" stroke="#9673A6" stroke-width="1.5"/>
-    <text x="100" y="470" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">CodePipeline</text>
-    <text x="100" y="485" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">(Backend)</text>
-    <text x="100" y="500" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Source → Build → Deploy</text>
+    <!-- CodePipeline Backend icon -->
+    <g transform="translate(58,465)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#C7131F" stroke="none"/>
+      <text x="22" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Code</text>
+      <text x="22" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Pipeline</text>
+      <text x="22" y="38" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">(BE)</text>
+    </g>
+    <text x="80" y="523" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">CodePipeline</text>
+    <text x="80" y="535" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">(Backend) Src&#x2192;Build&#x2192;Deploy</text>
 
     <!-- GitHub -->
-    <rect x="30" y="540" width="140" height="55" rx="6" fill="#F5F5F5" stroke="#333333" stroke-width="1.5"/>
-    <text x="100" y="562" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">GitHub</text>
-    <text x="100" y="580" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">(CodeStar Connection)</text>
+    <rect x="30" y="555" width="140" height="50" rx="6" fill="#24292E" stroke="#24292E" stroke-width="1.5"/>
+    <text x="100" y="575" fill="#FFFFFF" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">GitHub</text>
+    <text x="100" y="592" fill="#CCCCCC" font-family="Helvetica" font-size="9" text-anchor="middle">(CodeStar Connection)</text>
 
     <!-- GitHub to Pipelines arrows -->
-    <line x1="100" y1="540" x2="100" y2="510" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <polygon points="97,514 100,508 103,514" fill="#999999"/>
-    <line x1="100" y1="540" x2="100" y2="430" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="100" y1="555" x2="100" y2="540" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <polygon points="97,543 100,537 103,543" fill="#999999"/>
+    <line x1="80" y1="555" x2="80" y2="445" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
 
     <!-- Pipeline to S3 -->
-    <path d="M 170,400 L 220,400 L 220,260 L 270,260" fill="none" stroke="#9673A6" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="266,257 272,260 266,263" fill="#9673A6"/>
-    <text x="235" y="330" fill="#9673A6" font-family="Helvetica" font-size="8" transform="rotate(-90,235,330)">deploy dist/</text>
+    <path d="M 170,392 L 220,392 L 220,264 L 194,264" fill="none" stroke="#C7131F" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="198,261 192,264 198,267" fill="#C7131F"/>
+    <text x="233" y="330" fill="#C7131F" font-family="Helvetica" font-size="8" transform="rotate(-90,233,330)">deploy dist/</text>
 
     <!-- Pipeline to ECR -->
-    <path d="M 170,480 L 300,480 L 300,485 L 810,485" fill="none" stroke="#9673A6" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="806,482 812,485 806,488" fill="#9673A6"/>
-    <text x="500" y="477" fill="#9673A6" font-family="Helvetica" font-size="8">docker push</text>
+    <path d="M 170,487 L 300,487 L 300,484 L 835,484" fill="none" stroke="#C7131F" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="831,481 837,484 831,487" fill="#C7131F"/>
+    <text x="500" y="477" fill="#C7131F" font-family="Helvetica" font-size="8">docker push</text>
 
     <!-- Security Groups Legend -->
-    <rect x="15" y="830" width="460" height="60" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
-    <text x="25" y="848" fill="#333333" font-family="Helvetica" font-size="10" font-weight="bold">Security Groups Flow:</text>
-    <text x="25" y="864" fill="#555555" font-family="Helvetica" font-size="9">CloudFront VPC Origin SG → ALB SG (HTTP:80) → ECS SG (:3000) → DB SG (:5432)</text>
-    <text x="25" y="878" fill="#555555" font-family="Helvetica" font-size="9">Bastion SG (Specified IPs) → DB SG (:5432)</text>
+    <rect x="15" y="830" width="550" height="30" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="25" y="848" fill="#333333" font-family="Helvetica" font-size="9" font-weight="bold">Security Groups:</text>
+    <text x="120" y="848" fill="#555555" font-family="Helvetica" font-size="9">CF VPC Origin SG &#x2192; ALB SG (HTTP:80) &#x2192; ECS SG (:3000) &#x2192; DB SG (:5432) / Bastion SG &#x2192; DB SG</text>
 
     <!-- Region Label -->
     <text x="700" y="875" fill="#888888" font-family="Helvetica" font-size="11" font-style="italic">Region: ap-northeast-1 (Tokyo)</text>
 
     <!-- Legend -->
-    <rect x="530" y="830" width="280" height="60" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
-    <line x1="545" y1="850" x2="575" y2="850" stroke="#333333" stroke-width="1.5"/>
-    <text x="580" y="854" fill="#555555" font-family="Helvetica" font-size="9">Data Flow</text>
-    <line x1="545" y1="868" x2="575" y2="868" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <text x="580" y="872" fill="#555555" font-family="Helvetica" font-size="9">Config / Deploy / Auxiliary</text>
-    <rect x="670" y="842" width="40" height="14" rx="3" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="1"/>
-    <text x="715" y="854" fill="#555555" font-family="Helvetica" font-size="9">Compute/Network</text>
-    <rect x="670" y="860" width="40" height="14" rx="3" fill="#FFF2CC" stroke="#D6B656" stroke-width="1"/>
-    <text x="715" y="872" fill="#555555" font-family="Helvetica" font-size="9">Database</text>
+    <rect x="580" y="830" width="580" height="60" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
+    <rect x="595" y="842" width="24" height="14" rx="3" fill="#8C4FFF" stroke="none"/>
+    <text x="624" y="854" fill="#555555" font-family="Helvetica" font-size="9">Networking</text>
+    <rect x="700" y="842" width="24" height="14" rx="3" fill="#ED7100" stroke="none"/>
+    <text x="729" y="854" fill="#555555" font-family="Helvetica" font-size="9">Compute</text>
+    <rect x="790" y="842" width="24" height="14" rx="3" fill="#C925D1" stroke="none"/>
+    <text x="819" y="854" fill="#555555" font-family="Helvetica" font-size="9">Database</text>
+    <rect x="885" y="842" width="24" height="14" rx="3" fill="#E7157B" stroke="none"/>
+    <text x="914" y="854" fill="#555555" font-family="Helvetica" font-size="9">Management</text>
+    <rect x="990" y="842" width="24" height="14" rx="3" fill="#C7131F" stroke="none"/>
+    <text x="1019" y="854" fill="#555555" font-family="Helvetica" font-size="9">Developer Tools</text>
+    <line x1="595" y1="868" x2="625" y2="868" stroke="#333333" stroke-width="1.5"/>
+    <text x="630" y="872" fill="#555555" font-family="Helvetica" font-size="9">Data Flow</text>
+    <line x1="700" y1="868" x2="730" y2="868" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <text x="735" y="872" fill="#555555" font-family="Helvetica" font-size="9">Config / Deploy / Auxiliary</text>
+    <text x="900" y="872" fill="#888888" font-family="Helvetica" font-size="8" font-style="italic">* Icon colors follow AWS Architecture Icon standards</text>
   </g>
 </svg>

--- a/docs/diagrams/azure-architecture.drawio.svg
+++ b/docs/diagrams/azure-architecture.drawio.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1200" height="950" viewBox="-0.5 -0.5 1200 950" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;&lt;diagram name=&quot;Azure Architecture&quot; id=&quot;azure-arch&quot;&gt;&lt;mxGraphModel dx=&quot;1200&quot; dy=&quot;950&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1200&quot; pageHeight=&quot;950&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1200" height="950" viewBox="-0.5 -0.5 1200 950" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;&lt;diagram name=&quot;Azure Architecture&quot; id=&quot;azure-arch&quot;&gt;&lt;mxGraphModel dx=&quot;1200&quot; dy=&quot;950&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1200&quot; pageHeight=&quot;950&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;mxCell id=&quot;title&quot; value=&quot;Azure Infrastructure Architecture&quot; style=&quot;text;html=1;fontSize=20;fontStyle=1;fillColor=none;align=center;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;350&quot; y=&quot;10&quot; width=&quot;500&quot; height=&quot;30&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;user&quot; value=&quot;User&quot; style=&quot;shape=mxgraph.aws4.client;whiteSpace=wrap;html=1;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;555&quot; y=&quot;50&quot; width=&quot;50&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;auth0&quot; value=&quot;Auth0&amp;#xa;JWT / OAuth2 / JWKS&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f0f0f0;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;930&quot; y=&quot;50&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;fd&quot; value=&quot;Front Door Standard&amp;#xa;CDN / HTTPS / Health Probes&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=10;image=img/lib/azure2/networking/Front_Doors.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;556&quot; y=&quot;135&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;sa&quot; value=&quot;Storage Account&amp;#xa;$web (Static Web)&amp;#xa;React SPA&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=10;image=img/lib/azure2/storage/Storage_Accounts.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;146&quot; y=&quot;240&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;rg&quot; value=&quot;Resource Group&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;container=1;collapsible=0;recursiveResize=0;fillColor=none;strokeColor=#0078D4;strokeWidth=2;dashed=1;dashPattern=8 4;verticalAlign=top;fontColor=#0078D4;fontStyle=1;fontSize=12;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;340&quot; y=&quot;220&quot; width=&quot;830&quot; height=&quot;620&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;vnet&quot; value=&quot;VNet 10.0.0.0/24&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=left;fontSize=11;image=img/lib/azure2/networking/Virtual_Networks.svg;container=1;collapsible=0;recursiveResize=0;fillColor=none;strokeColor=#00A36C;strokeWidth=2;dashed=1;dashPattern=6 3;verticalAlign=top;fontColor=#00A36C;fontStyle=1;spacingLeft=30;&quot; vertex=&quot;1&quot; parent=&quot;rg&quot;&gt;&lt;mxGeometry x=&quot;30&quot; y=&quot;40&quot; width=&quot;540&quot; height=&quot;480&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;appsvc&quot; value=&quot;App Service (Linux B1)&amp;#xa;Docker Container&amp;#xa;NestJS API (:3000)&amp;#xa;Managed Identity&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/app_services/App_Services.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;526&quot; y=&quot;360&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;pgsql&quot; value=&quot;PostgreSQL Flexible Server&amp;#xa;v16 / B_Standard_B1ms / 32GB&amp;#xa;Public Access: OFF / Backup: 7d&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/databases/Azure_Database_PostgreSQL_Server.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;526&quot; y=&quot;550&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;acr&quot; value=&quot;Container Registry&amp;#xa;(ACR)&amp;#xa;AcrPull: Managed Identity&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/containers/Container_Registries.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;990&quot; y=&quot;310&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;kv&quot; value=&quot;Key Vault&amp;#xa;Auth0 / DB / Deploy Config&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/security/Key_Vaults.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;990&quot; y=&quot;410&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;la&quot; value=&quot;Log Analytics Workspace&amp;#xa;Console/App/HTTP Logs&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/analytics/Log_Analytics_Workspaces.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;990&quot; y=&quot;510&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;dns&quot; value=&quot;Private DNS Zone&amp;#xa;.postgres.database.azure.com&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/networking/DNS_Zones.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;730&quot; y=&quot;555&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e1&quot; value=&quot;HTTPS&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;user&quot; target=&quot;fd&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e2&quot; value=&quot;/* (Web Origin)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;fd&quot; target=&quot;sa&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e3&quot; value=&quot;/api/* (ServiceTag)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;fd&quot; target=&quot;appsvc&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e4&quot; value=&quot;:5432 (SSL)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;appsvc&quot; target=&quot;pgsql&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e5&quot; value=&quot;image pull&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;acr&quot; target=&quot;appsvc&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e6&quot; value=&quot;secrets ref&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;kv&quot; target=&quot;appsvc&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e7&quot; value=&quot;diagnostics&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;appsvc&quot; target=&quot;la&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;e8&quot; value=&quot;OAuth2 / JWT (RS256)&quot; style=&quot;edgeStyle=orthogonalEdgeStyle;rounded=1;dashed=1;fontSize=9;&quot; edge=&quot;1&quot; source=&quot;user&quot; target=&quot;auth0&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry relative=&quot;1&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
   <defs/>
   <g>
     <!-- Title -->
@@ -26,79 +26,105 @@
     <polygon points="916,62 922,65 916,68" fill="#999999"/>
     <text x="760" y="58" fill="#999999" font-family="Helvetica" font-size="9" text-anchor="middle">OAuth2 / JWT (RS256)</text>
 
-    <!-- Front Door -->
-    <rect x="430" y="135" width="300" height="55" rx="10" fill="#BDD7EE" stroke="#2E75B6" stroke-width="2"/>
-    <text x="580" y="157" fill="#1A4472" font-family="Helvetica" font-size="14" text-anchor="middle" font-weight="bold">Azure Front Door Standard</text>
-    <text x="580" y="177" fill="#2E75B6" font-family="Helvetica" font-size="10" text-anchor="middle">CDN / HTTPS / Health Probes</text>
+    <!-- Front Door icon -->
+    <g transform="translate(556,135)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#0078D4" stroke="none"/>
+      <text x="24" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Front</text>
+      <text x="24" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Door</text>
+      <text x="24" y="40" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Standard</text>
+    </g>
+    <text x="580" y="198" fill="#1A4472" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Front Door Standard</text>
+    <text x="580" y="212" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">CDN / HTTPS / Health Probes</text>
 
     <!-- User to Front Door arrow -->
     <line x1="580" y1="115" x2="580" y2="135" stroke="#333333" stroke-width="2"/>
     <polygon points="576,132 580,138 584,132" fill="#333333"/>
     <text x="595" y="128" fill="#333333" font-family="Helvetica" font-size="9">HTTPS</text>
 
-    <!-- Storage Account -->
-    <rect x="70" y="230" width="200" height="60" rx="10" fill="#BDD7EE" stroke="#2E75B6" stroke-width="2"/>
-    <text x="170" y="252" fill="#1A4472" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">Storage Account</text>
-    <text x="170" y="268" fill="#2E75B6" font-family="Helvetica" font-size="10" text-anchor="middle">$web Container (Static Web)</text>
-    <text x="170" y="282" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">React SPA / Error Doc: index.html</text>
+    <!-- Storage Account icon -->
+    <g transform="translate(146,235)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#0078D4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Storage</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Account</text>
+      <text x="24" y="40" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">$web</text>
+    </g>
+    <text x="170" y="298" fill="#1A4472" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Storage Account</text>
+    <text x="170" y="312" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">$web Container (Static Web)</text>
+    <text x="170" y="326" fill="#2E75B6" font-family="Helvetica" font-size="8" text-anchor="middle">React SPA / Error Doc: index.html</text>
 
     <!-- Front Door to Storage arrow -->
-    <path d="M 430,165 L 320,165 L 320,258 L 270,258" fill="none" stroke="#333333" stroke-width="1.5"/>
-    <polygon points="274,255 268,258 274,261" fill="#333333"/>
-    <text x="340" y="158" fill="#333333" font-family="Helvetica" font-size="9">/* (Web Origin)</text>
+    <path d="M 556,159 L 320,159 L 320,259 L 194,259" fill="none" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="198,256 192,259 198,262" fill="#333333"/>
+    <text x="340" y="152" fill="#333333" font-family="Helvetica" font-size="9">/* (Web Origin)</text>
 
     <!-- Resource Group Box -->
     <rect x="340" y="220" width="830" height="620" rx="12" fill="none" stroke="#0078D4" stroke-width="2.5" stroke-dasharray="8,4"/>
     <rect x="350" y="220" width="200" height="22" rx="4" fill="#E8F1FA" stroke="none"/>
-    <text x="360" y="236" fill="#0078D4" font-family="Helvetica" font-size="12" font-weight="bold">Resource Group</text>
+    <g transform="translate(352,222)">
+      <rect x="0" y="0" width="18" height="18" rx="2" fill="#0078D4" stroke="none"/>
+      <text x="9" y="13" fill="#FFFFFF" font-family="Helvetica" font-size="8" text-anchor="middle" font-weight="bold">RG</text>
+    </g>
+    <text x="378" y="236" fill="#0078D4" font-family="Helvetica" font-size="12" font-weight="bold">Resource Group</text>
 
     <!-- VNet Box -->
     <rect x="370" y="260" width="540" height="480" rx="10" fill="none" stroke="#00A36C" stroke-width="2" stroke-dasharray="6,3"/>
     <rect x="380" y="260" width="180" height="20" rx="4" fill="#E6F4EA" stroke="none"/>
-    <text x="390" y="275" fill="#00A36C" font-family="Helvetica" font-size="11" font-weight="bold">VNet 10.0.0.0/24</text>
+    <g transform="translate(382,262)">
+      <rect x="0" y="0" width="16" height="16" rx="2" fill="#00A36C" stroke="none"/>
+      <text x="8" y="12" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">VN</text>
+    </g>
+    <text x="406" y="275" fill="#00A36C" font-family="Helvetica" font-size="11" font-weight="bold">VNet 10.0.0.0/24</text>
 
     <!-- App Service Subnet -->
     <rect x="390" y="300" width="500" height="170" rx="8" fill="#F0F8FF" stroke="#5B9BD5" stroke-width="1.5"/>
     <text x="400" y="318" fill="#2E75B6" font-family="Helvetica" font-size="10" font-weight="bold">App Service Subnet 10.0.0.0/29</text>
     <text x="400" y="332" fill="#5B9BD5" font-family="Helvetica" font-size="9">(Delegation: Microsoft.Web/serverFarms)</text>
 
-    <!-- App Service -->
-    <rect x="420" y="350" width="260" height="100" rx="8" fill="#BDD7EE" stroke="#2E75B6" stroke-width="2"/>
-    <text x="550" y="372" fill="#1A4472" font-family="Helvetica" font-size="13" text-anchor="middle" font-weight="bold">App Service (Linux B1)</text>
-    <text x="550" y="390" fill="#2E75B6" font-family="Helvetica" font-size="10" text-anchor="middle">Docker Container: backend:latest</text>
-    <text x="550" y="406" fill="#2E75B6" font-family="Helvetica" font-size="10" text-anchor="middle">NestJS API (:3000)</text>
-    <text x="550" y="422" fill="#2E75B6" font-family="Helvetica" font-size="10" text-anchor="middle">System Assigned Managed Identity</text>
-    <text x="550" y="438" fill="#2E75B6" font-family="Helvetica" font-size="10" text-anchor="middle">IP: Allow FrontDoor.Backend only</text>
+    <!-- App Service icon -->
+    <g transform="translate(526,360)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#0078D4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">App</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Service</text>
+      <text x="24" y="38" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Linux B1</text>
+    </g>
+    <text x="550" y="423" fill="#1A4472" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">App Service (Linux B1)</text>
+    <text x="550" y="437" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">Docker Container: backend:latest</text>
+    <text x="550" y="451" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">NestJS API (:3000) / Managed Identity</text>
 
     <!-- Front Door to App Service arrow -->
-    <path d="M 640,190 L 750,190 L 750,340 L 550,340 L 550,350" fill="none" stroke="#333333" stroke-width="1.5"/>
-    <polygon points="547,346 550,352 553,346" fill="#333333"/>
-    <text x="765" y="280" fill="#333333" font-family="Helvetica" font-size="9" transform="rotate(90,765,280)">/api/* (ServiceTag)</text>
+    <path d="M 604,159 L 750,159 L 750,340 L 550,340 L 550,360" fill="none" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="547,356 550,362 553,356" fill="#333333"/>
+    <text x="765" y="260" fill="#333333" font-family="Helvetica" font-size="9" transform="rotate(90,765,260)">/api/* (ServiceTag)</text>
 
     <!-- DB Subnet -->
     <rect x="390" y="500" width="500" height="170" rx="8" fill="#FFF8F0" stroke="#ED7D31" stroke-width="1.5"/>
     <text x="400" y="518" fill="#C05A15" font-family="Helvetica" font-size="10" font-weight="bold">DB Subnet 10.0.0.8/29</text>
     <text x="400" y="532" fill="#ED7D31" font-family="Helvetica" font-size="9">(Delegation: Microsoft.DBforPostgreSQL/flexibleServers)</text>
 
-    <!-- PostgreSQL -->
-    <ellipse cx="550" cy="560" rx="100" ry="14" fill="#FFF2CC" stroke="#D6B656" stroke-width="2"/>
-    <rect x="450" y="560" width="200" height="65" fill="#FFF2CC" stroke="#D6B656" stroke-width="2"/>
-    <ellipse cx="550" cy="625" rx="100" ry="14" fill="#FFF2CC" stroke="#D6B656" stroke-width="2"/>
-    <line x1="450" y1="560" x2="450" y2="625" stroke="#D6B656" stroke-width="2"/>
-    <line x1="650" y1="560" x2="650" y2="625" stroke="#D6B656" stroke-width="2"/>
-    <text x="550" y="583" fill="#333333" font-family="Helvetica" font-size="12" text-anchor="middle" font-weight="bold">PostgreSQL Flexible Server</text>
-    <text x="550" y="599" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">v16 / B_Standard_B1ms / 32GB</text>
-    <text x="550" y="615" fill="#555555" font-family="Helvetica" font-size="10" text-anchor="middle">Public Access: OFF / Backup: 7d</text>
+    <!-- PostgreSQL icon -->
+    <g transform="translate(526,555)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#0078D4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">PostgreSQL</text>
+      <text x="24" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Flexible</text>
+      <text x="24" y="40" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Server</text>
+    </g>
+    <text x="550" y="618" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">PostgreSQL Flexible Server</text>
+    <text x="550" y="632" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">v16 / B_Standard_B1ms / 32GB</text>
+    <text x="550" y="646" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Public Access: OFF / Backup: 7d</text>
 
-    <!-- Private DNS Zone -->
-    <rect x="700" y="550" width="170" height="45" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
-    <text x="785" y="568" fill="#00A36C" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Private DNS Zone</text>
-    <text x="785" y="584" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">private.postgres.database.azure.com</text>
+    <!-- Private DNS Zone icon -->
+    <g transform="translate(730,555)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#2E75B6" stroke="none"/>
+      <text x="22" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">DNS</text>
+      <text x="22" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Private</text>
+    </g>
+    <text x="752" y="612" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Private DNS Zone</text>
+    <text x="752" y="625" fill="#2E75B6" font-family="Helvetica" font-size="7" text-anchor="middle">.postgres.database.azure.com</text>
 
     <!-- App Service to PostgreSQL arrow -->
-    <line x1="550" y1="450" x2="550" y2="546" stroke="#333333" stroke-width="1.5"/>
-    <polygon points="547,542 550,548 553,542" fill="#333333"/>
-    <text x="565" y="500" fill="#333333" font-family="Helvetica" font-size="9">:5432 (SSL)</text>
+    <line x1="550" y1="455" x2="550" y2="555" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="547,551 550,557 553,551" fill="#333333"/>
+    <text x="565" y="505" fill="#333333" font-family="Helvetica" font-size="9">:5432 (SSL)</text>
 
     <!-- Default Subnet -->
     <rect x="390" y="695" width="500" height="35" rx="6" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
@@ -106,112 +132,141 @@
 
     <!-- Right side services -->
 
-    <!-- ACR -->
-    <rect x="960" y="310" width="170" height="55" rx="8" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="1045" y="332" fill="#1A4472" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Container Registry</text>
-    <text x="1045" y="350" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">(ACR) Managed Identity: AcrPull</text>
+    <!-- ACR icon -->
+    <g transform="translate(990,310)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#0078D4" stroke="none"/>
+      <text x="24" y="20" fill="#FFFFFF" font-family="Helvetica" font-size="8" text-anchor="middle" font-weight="bold">ACR</text>
+      <text x="24" y="34" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle">Registry</text>
+    </g>
+    <text x="1014" y="373" fill="#1A4472" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Container Registry</text>
+    <text x="1014" y="387" fill="#2E75B6" font-family="Helvetica" font-size="8" text-anchor="middle">(ACR) AcrPull: Managed Identity</text>
 
     <!-- ACR to App Service -->
-    <path d="M 960,340 L 905,340 L 905,380 L 680,380" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="684,377 678,380 684,383" fill="#999999"/>
+    <path d="M 990,340 L 900,340 L 900,384 L 574,384" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="578,381 572,384 578,387" fill="#999999"/>
     <text x="850" y="335" fill="#999999" font-family="Helvetica" font-size="9">image pull</text>
 
-    <!-- Key Vault -->
-    <rect x="960" y="395" width="170" height="80" rx="8" fill="#E1D5E7" stroke="#9673A6" stroke-width="1.5"/>
-    <text x="1045" y="415" fill="#5B3D73" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Key Vault</text>
-    <text x="1045" y="432" fill="#9673A6" font-family="Helvetica" font-size="9" text-anchor="middle">Auth0 Credentials</text>
-    <text x="1045" y="446" fill="#9673A6" font-family="Helvetica" font-size="9" text-anchor="middle">DB Connection String</text>
-    <text x="1045" y="460" fill="#9673A6" font-family="Helvetica" font-size="9" text-anchor="middle">Deploy Config / OIDC</text>
+    <!-- Key Vault icon -->
+    <g transform="translate(990,415)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#00A36C" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Key</text>
+      <text x="24" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Vault</text>
+      <rect x="14" y="32" width="20" height="8" rx="2" fill="#FFFFFF" fill-opacity="0.3" stroke="none"/>
+    </g>
+    <text x="1014" y="478" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Key Vault</text>
+    <text x="1014" y="492" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Auth0 Credentials</text>
+    <text x="1014" y="504" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">DB Connection / Deploy Config</text>
 
     <!-- Key Vault to App Service -->
-    <path d="M 960,440 L 900,440 L 900,400 L 680,400" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="684,397 678,400 684,403" fill="#999999"/>
+    <path d="M 990,440 L 900,440 L 900,400 L 574,400" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="578,397 572,400 578,403" fill="#999999"/>
     <text x="820" y="435" fill="#999999" font-family="Helvetica" font-size="9">secrets ref</text>
 
-    <!-- Log Analytics -->
-    <rect x="960" y="505" width="170" height="60" rx="8" fill="#F5F5F5" stroke="#999999" stroke-width="1.5"/>
-    <text x="1045" y="525" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Log Analytics</text>
-    <text x="1045" y="540" fill="#666666" font-family="Helvetica" font-size="9" text-anchor="middle">Workspace</text>
-    <text x="1045" y="555" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Console/App/HTTP Logs + Metrics</text>
+    <!-- Log Analytics icon -->
+    <g transform="translate(990,520)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#5B9BD5" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Log</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Analytics</text>
+      <rect x="8" y="30" width="32" height="3" rx="1" fill="#FFFFFF" fill-opacity="0.4" stroke="none"/>
+      <rect x="8" y="36" width="24" height="3" rx="1" fill="#FFFFFF" fill-opacity="0.3" stroke="none"/>
+    </g>
+    <text x="1014" y="583" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Log Analytics</text>
+    <text x="1014" y="597" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Workspace</text>
+    <text x="1014" y="610" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">Console/App/HTTP Logs + Metrics</text>
 
     <!-- App Service to Log Analytics -->
-    <path d="M 680,420 L 920,420 L 920,530 L 960,530" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="956,527 962,530 956,533" fill="#999999"/>
+    <path d="M 574,395 L 920,395 L 920,544 L 990,544" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="986,541 992,544 986,547" fill="#999999"/>
     <text x="930" y="478" fill="#999999" font-family="Helvetica" font-size="9" transform="rotate(90,930,478)">diagnostics</text>
 
     <!-- CI/CD Section -->
     <rect x="15" y="340" width="170" height="330" rx="8" fill="none" stroke="#00A36C" stroke-width="1.5" stroke-dasharray="5,3"/>
     <text x="100" y="358" fill="#00A36C" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">CI/CD (GitHub Actions)</text>
 
-    <!-- GitHub Actions Backend -->
-    <rect x="30" y="375" width="140" height="65" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
-    <text x="100" y="393" fill="#00563F" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">deploy-backend</text>
-    <text x="100" y="408" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">Docker Build → ACR Push</text>
-    <text x="100" y="420" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">→ App Service Update</text>
-    <text x="100" y="432" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">(workflow_dispatch)</text>
+    <!-- GitHub Actions Backend icon -->
+    <g transform="translate(58,380)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#2DA44E" stroke="none"/>
+      <text x="22" y="14" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">GH</text>
+      <text x="22" y="24" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Actions</text>
+      <text x="22" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">(Backend)</text>
+    </g>
+    <text x="80" y="438" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">deploy-backend</text>
+    <text x="80" y="450" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">Docker Build &#x2192; ACR Push</text>
+    <text x="80" y="460" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">&#x2192; App Service Update</text>
 
-    <!-- GitHub Actions Frontend -->
-    <rect x="30" y="460" width="140" height="65" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
-    <text x="100" y="478" fill="#00563F" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">deploy-frontend</text>
-    <text x="100" y="493" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">yarn build → Blob Upload</text>
-    <text x="100" y="505" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">→ Front Door Cache Purge</text>
-    <text x="100" y="517" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">(workflow_dispatch)</text>
+    <!-- GitHub Actions Frontend icon -->
+    <g transform="translate(58,475)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#2DA44E" stroke="none"/>
+      <text x="22" y="14" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">GH</text>
+      <text x="22" y="24" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Actions</text>
+      <text x="22" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">(Frontend)</text>
+    </g>
+    <text x="80" y="533" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">deploy-frontend</text>
+    <text x="80" y="545" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">yarn build &#x2192; Blob Upload</text>
+    <text x="80" y="555" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">&#x2192; Front Door Cache Purge</text>
 
     <!-- Service Principal -->
-    <rect x="30" y="550" width="140" height="55" rx="6" fill="#F5F5F5" stroke="#333333" stroke-width="1.5"/>
-    <text x="100" y="570" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Service Principal</text>
-    <text x="100" y="585" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">OIDC (Federated)</text>
-    <text x="100" y="598" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">No Static Secrets</text>
+    <g transform="translate(58,570)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="22" y="14" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Service</text>
+      <text x="22" y="24" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Principal</text>
+      <text x="22" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">OIDC</text>
+    </g>
+    <text x="80" y="628" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Service Principal</text>
+    <text x="80" y="640" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">OIDC (Federated)</text>
+    <text x="80" y="650" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">No Static Secrets</text>
 
     <!-- GitHub -->
-    <rect x="30" y="625" width="140" height="40" rx="6" fill="#24292E" stroke="#24292E" stroke-width="1.5"/>
-    <text x="100" y="650" fill="#FFFFFF" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">GitHub Repository</text>
+    <rect x="30" y="655" width="140" height="40" rx="6" fill="#24292E" stroke="#24292E" stroke-width="1.5"/>
+    <text x="100" y="680" fill="#FFFFFF" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">GitHub Repository</text>
 
     <!-- Connections in CI/CD -->
-    <line x1="100" y1="625" x2="100" y2="605" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <polygon points="97,609 100,603 103,609" fill="#999999"/>
+    <line x1="100" y1="655" x2="100" y2="620" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <polygon points="97,623 100,617 103,623" fill="#999999"/>
 
-    <line x1="100" y1="550" x2="100" y2="525" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <polygon points="97,529 100,523 103,529" fill="#999999"/>
-    <text x="115" y="540" fill="#999999" font-family="Helvetica" font-size="8">OIDC</text>
+    <line x1="80" y1="570" x2="80" y2="525" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <polygon points="77,528 80,522 83,528" fill="#999999"/>
+    <text x="95" y="548" fill="#999999" font-family="Helvetica" font-size="8">OIDC</text>
 
-    <line x1="100" y1="460" x2="100" y2="440" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <polygon points="97,444 100,438 103,444" fill="#999999"/>
+    <line x1="80" y1="475" x2="80" y2="430" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <polygon points="77,433 80,427 83,433" fill="#999999"/>
 
     <!-- Pipeline to Storage Account -->
-    <path d="M 170,493 L 220,493 L 220,260 L 270,260" fill="none" stroke="#00A36C" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="266,257 272,260 266,263" fill="#00A36C"/>
+    <path d="M 170,497 L 220,497 L 220,259 L 194,259" fill="none" stroke="#00A36C" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="198,256 192,259 198,262" fill="#00A36C"/>
     <text x="230" y="380" fill="#00A36C" font-family="Helvetica" font-size="8" transform="rotate(-90,230,380)">upload $web</text>
 
     <!-- Pipeline to ACR -->
-    <path d="M 170,405 L 260,405 L 260,338 L 960,338" fill="none" stroke="#00A36C" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="956,335 962,338 956,341" fill="#00A36C"/>
-    <text x="610" y="332" fill="#00A36C" font-family="Helvetica" font-size="8">docker push</text>
+    <path d="M 170,402 L 260,402 L 260,334 L 990,334" fill="none" stroke="#00A36C" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="986,331 992,334 986,337" fill="#00A36C"/>
+    <text x="610" y="328" fill="#00A36C" font-family="Helvetica" font-size="8">docker push</text>
 
     <!-- Pipeline to Key Vault -->
-    <path d="M 170,418 L 280,418 L 280,435 L 960,435" fill="none" stroke="#9673A6" stroke-width="1" stroke-dasharray="5,3"/>
-    <polygon points="956,432 962,435 956,438" fill="#9673A6"/>
-    <text x="610" y="430" fill="#9673A6" font-family="Helvetica" font-size="8">fetch secrets</text>
+    <path d="M 170,415 L 280,415 L 280,439 L 990,439" fill="none" stroke="#9673A6" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="986,436 992,439 986,442" fill="#9673A6"/>
+    <text x="610" y="434" fill="#9673A6" font-family="Helvetica" font-size="8">fetch secrets</text>
 
     <!-- Legend -->
     <rect x="15" y="865" width="460" height="70" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
     <text x="25" y="883" fill="#333333" font-family="Helvetica" font-size="10" font-weight="bold">Network Security:</text>
-    <text x="25" y="899" fill="#555555" font-family="Helvetica" font-size="9">Front Door (ServiceTag: AzureFrontDoor.Backend) → App Service (IP Restriction) → PostgreSQL (VNet Private)</text>
+    <text x="25" y="899" fill="#555555" font-family="Helvetica" font-size="9">Front Door (ServiceTag: AzureFrontDoor.Backend) &#x2192; App Service (IP Restriction) &#x2192; PostgreSQL (VNet Private)</text>
     <text x="25" y="913" fill="#555555" font-family="Helvetica" font-size="9">Secrets: Key Vault Reference (@Microsoft.KeyVault) / Auth: OIDC Federated Credentials</text>
-    <text x="25" y="927" fill="#555555" font-family="Helvetica" font-size="9">Container: ACR → App Service (Managed Identity AcrPull) / Database: Private DNS Zone + Subnet Delegation</text>
+    <text x="25" y="927" fill="#555555" font-family="Helvetica" font-size="9">Container: ACR &#x2192; App Service (Managed Identity AcrPull) / Database: Private DNS Zone + Subnet Delegation</text>
 
     <!-- Region Label -->
     <text x="700" y="900" fill="#888888" font-family="Helvetica" font-size="11" font-style="italic">Region: japaneast (East Japan)</text>
 
     <!-- Color Legend -->
-    <rect x="530" y="865" width="280" height="60" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
-    <line x1="545" y1="882" x2="575" y2="882" stroke="#333333" stroke-width="1.5"/>
-    <text x="580" y="886" fill="#555555" font-family="Helvetica" font-size="9">Data Flow</text>
-    <line x1="545" y1="898" x2="575" y2="898" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
-    <text x="580" y="902" fill="#555555" font-family="Helvetica" font-size="9">Config / Deploy / Auxiliary</text>
-    <rect x="670" y="876" width="40" height="12" rx="3" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1"/>
-    <text x="715" y="886" fill="#555555" font-family="Helvetica" font-size="9">Azure Service</text>
-    <rect x="670" y="894" width="40" height="12" rx="3" fill="#FFF2CC" stroke="#D6B656" stroke-width="1"/>
-    <text x="715" y="904" fill="#555555" font-family="Helvetica" font-size="9">Database</text>
+    <rect x="530" y="865" width="360" height="60" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
+    <rect x="545" y="878" width="24" height="14" rx="3" fill="#0078D4" stroke="none"/>
+    <text x="574" y="890" fill="#555555" font-family="Helvetica" font-size="9">Azure Core Service</text>
+    <rect x="680" y="878" width="24" height="14" rx="3" fill="#00A36C" stroke="none"/>
+    <text x="709" y="890" fill="#555555" font-family="Helvetica" font-size="9">Security / Network</text>
+    <rect x="800" y="878" width="24" height="14" rx="3" fill="#2DA44E" stroke="none"/>
+    <text x="829" y="890" fill="#555555" font-family="Helvetica" font-size="9">GitHub</text>
+    <line x1="545" y1="902" x2="575" y2="902" stroke="#333333" stroke-width="1.5"/>
+    <text x="580" y="906" fill="#555555" font-family="Helvetica" font-size="9">Data Flow</text>
+    <line x1="680" y1="902" x2="710" y2="902" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <text x="715" y="906" fill="#555555" font-family="Helvetica" font-size="9">Config / Deploy / Auxiliary</text>
   </g>
 </svg>

--- a/docs/diagrams/cicd-pipeline.drawio.svg
+++ b/docs/diagrams/cicd-pipeline.drawio.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1200" height="820" viewBox="-0.5 -0.5 1200 820" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;&lt;diagram name=&quot;CI/CD Pipeline&quot; id=&quot;cicd-pipe&quot;&gt;&lt;mxGraphModel dx=&quot;1200&quot; dy=&quot;820&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1200&quot; pageHeight=&quot;820&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1200" height="820" viewBox="-0.5 -0.5 1200 820" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;&lt;diagram name=&quot;CI/CD Pipeline&quot; id=&quot;cicd-pipe&quot;&gt;&lt;mxGraphModel dx=&quot;1200&quot; dy=&quot;820&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1200&quot; pageHeight=&quot;820&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;mxCell id=&quot;title&quot; value=&quot;CI/CD Pipeline Architecture&quot; style=&quot;text;html=1;fontSize=20;fontStyle=1;fillColor=none;align=center;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;350&quot; y=&quot;10&quot; width=&quot;500&quot; height=&quot;30&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;github&quot; value=&quot;GitHub Repository&amp;#xa;template-spa-webapp&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#24292E;fontColor=#FFFFFF;strokeColor=#24292E;fontSize=11;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;480&quot; y=&quot;55&quot; width=&quot;240&quot; height=&quot;70&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_src&quot; value=&quot;Source&amp;#xa;CodeStar Connection&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C7131F;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.codestar;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;80&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_build&quot; value=&quot;Build&amp;#xa;CodeBuild&amp;#xa;docker build &amp;amp; push&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C7131F;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.codebuild;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;240&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_deploy&quot; value=&quot;Deploy&amp;#xa;ECS Rolling Update&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecs;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;400&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_ecr&quot; value=&quot;ECR&amp;#xa;Container Registry&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecr;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;400&quot; y=&quot;380&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_ecs&quot; value=&quot;ECS Fargate&amp;#xa;Running Service&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.fargate;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;240&quot; y=&quot;380&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_fe_src&quot; value=&quot;Source&amp;#xa;CodeStar&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C7131F;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.codestar;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;60&quot; y=&quot;520&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_fe_build&quot; value=&quot;Build (CodeBuild)&amp;#xa;yarn build &#8594; S3 Upload&amp;#xa;&#8594; CF Invalidation&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C7131F;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=8;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.codebuild;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;240&quot; y=&quot;520&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_s3&quot; value=&quot;S3 Bucket&amp;#xa;dist/ uploaded&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#277116;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;240&quot; y=&quot;620&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;aws_cf&quot; value=&quot;CloudFront&amp;#xa;Cache Invalidated&quot; style=&quot;outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudfront;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;400&quot; y=&quot;620&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_login&quot; value=&quot;Azure Login&amp;#xa;(OIDC)&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/identity/Azure_Active_Directory.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;660&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_kv_be&quot; value=&quot;Key Vault&amp;#xa;Fetch Secrets&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/security/Key_Vaults.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;770&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_docker&quot; value=&quot;Docker Build&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/containers/Container_Registries.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;880&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_acr&quot; value=&quot;ACR Push&amp;#xa;:SHA + :latest&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/containers/Container_Registries.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;990&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_appsvc&quot; value=&quot;App Service&amp;#xa;Update + Restart&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/app_services/App_Services.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;1100&quot; y=&quot;235&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_fe_login&quot; value=&quot;Azure Login&amp;#xa;(OIDC)&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/identity/Azure_Active_Directory.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;660&quot; y=&quot;520&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_kv_fe&quot; value=&quot;Key Vault&amp;#xa;Auth0 + Config&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/security/Key_Vaults.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;760&quot; y=&quot;520&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_yarn&quot; value=&quot;Yarn Build&amp;#xa;Node 23.1&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#E6F4EA;strokeColor=#00A36C;fontSize=9;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;850&quot; y=&quot;520&quot; width=&quot;80&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_blob&quot; value=&quot;Blob Upload&amp;#xa;$web container&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/storage/Storage_Accounts.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;970&quot; y=&quot;520&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;az_fd&quot; value=&quot;Front Door&amp;#xa;Cache Purge&quot; style=&quot;image;aspect=fixed;html=1;points=[];align=center;fontSize=9;image=img/lib/azure2/networking/Front_Doors.svg;verticalLabelPosition=bottom;verticalAlign=top;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;1080&quot; y=&quot;520&quot; width=&quot;40&quot; height=&quot;40&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#333333"/>
@@ -35,86 +35,115 @@
     <text x="50" y="215" fill="#CC7A00" font-family="Helvetica" font-size="12" font-weight="bold">Backend Pipeline</text>
     <text x="260" y="215" fill="#CC7A00" font-family="Helvetica" font-size="9">(path filter: backend/**)</text>
 
-    <!-- Source -->
-    <rect x="60" y="235" width="120" height="55" rx="6" fill="#FFF2CC" stroke="#FF9900" stroke-width="1.5"/>
-    <text x="120" y="258" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Source</text>
-    <text x="120" y="275" fill="#666666" font-family="Helvetica" font-size="9" text-anchor="middle">CodeStar</text>
-    <text x="120" y="285" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Connection</text>
+    <!-- Source icon -->
+    <g transform="translate(70,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#C7131F" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Code</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Star</text>
+      <text x="20" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Source</text>
+    </g>
+    <text x="90" y="290" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Source</text>
+    <text x="90" y="303" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">CodeStar Connection</text>
 
-    <!-- Build -->
-    <rect x="220" y="235" width="140" height="55" rx="6" fill="#FFF2CC" stroke="#FF9900" stroke-width="1.5"/>
-    <text x="290" y="253" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Build</text>
-    <text x="290" y="268" fill="#666666" font-family="Helvetica" font-size="9" text-anchor="middle">CodeBuild</text>
-    <text x="290" y="282" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">docker build &amp; push</text>
+    <!-- Build icon -->
+    <g transform="translate(240,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#C7131F" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Code</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Build</text>
+    </g>
+    <text x="260" y="290" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Build</text>
+    <text x="260" y="303" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">docker build &amp; push</text>
 
-    <!-- Deploy -->
-    <rect x="400" y="235" width="140" height="55" rx="6" fill="#FFF2CC" stroke="#FF9900" stroke-width="1.5"/>
-    <text x="470" y="253" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Deploy</text>
-    <text x="470" y="268" fill="#666666" font-family="Helvetica" font-size="9" text-anchor="middle">ECS Rolling</text>
-    <text x="470" y="282" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">imagedefinitions.json</text>
+    <!-- Deploy icon -->
+    <g transform="translate(400,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#ED7100" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">ECS</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Deploy</text>
+    </g>
+    <text x="420" y="290" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Deploy</text>
+    <text x="420" y="303" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">ECS Rolling Update</text>
 
     <!-- Arrows between stages -->
-    <line x1="180" y1="262" x2="220" y2="262" stroke="#FF9900" stroke-width="2" marker-end="url(#arrowhead-aws)"/>
-    <line x1="360" y1="262" x2="400" y2="262" stroke="#FF9900" stroke-width="2" marker-end="url(#arrowhead-aws)"/>
+    <line x1="110" y1="255" x2="240" y2="255" stroke="#FF9900" stroke-width="2" marker-end="url(#arrowhead-aws)"/>
+    <line x1="280" y1="255" x2="400" y2="255" stroke="#FF9900" stroke-width="2" marker-end="url(#arrowhead-aws)"/>
 
     <!-- AWS Backend detail boxes -->
-    <rect x="60" y="310" width="130" height="40" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
-    <text x="125" y="326" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">GitHub → ZIP</text>
-    <text x="125" y="340" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">S3 Artifact Store</text>
+    <rect x="60" y="320" width="130" height="40" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="125" y="336" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">GitHub &#x2192; ZIP</text>
+    <text x="125" y="350" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">S3 Artifact Store</text>
 
-    <rect x="220" y="310" width="150" height="55" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
-    <text x="295" y="326" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">ECR Login</text>
-    <text x="295" y="340" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Docker Build (Dockerfile)</text>
-    <text x="295" y="354" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Push :latest + :SHA</text>
+    <rect x="220" y="320" width="150" height="55" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="295" y="336" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">ECR Login</text>
+    <text x="295" y="350" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Docker Build (Dockerfile)</text>
+    <text x="295" y="364" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Push :latest + :SHA</text>
 
-    <rect x="400" y="310" width="150" height="55" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
-    <text x="475" y="326" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Update Task Definition</text>
-    <text x="475" y="340" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">ECS Service Update</text>
-    <text x="475" y="354" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Rolling Deployment</text>
+    <rect x="400" y="320" width="150" height="55" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="475" y="336" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Update Task Definition</text>
+    <text x="475" y="350" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">ECS Service Update</text>
+    <text x="475" y="364" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Rolling Deployment</text>
 
     <!-- Target boxes for backend -->
-    <rect x="400" y="385" width="140" height="50" rx="6" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="1.5"/>
-    <text x="470" y="405" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">ECR</text>
-    <text x="470" y="420" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Container Registry</text>
+    <g transform="translate(400,392)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#ED7100" stroke="none"/>
+      <text x="20" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">ECR</text>
+      <text x="20" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Registry</text>
+    </g>
+    <text x="420" y="445" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">ECR</text>
 
-    <rect x="220" y="385" width="140" height="50" rx="6" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="1.5"/>
-    <text x="290" y="405" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">ECS Fargate</text>
-    <text x="290" y="420" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Running Service</text>
+    <g transform="translate(240,392)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#ED7100" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">ECS</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Fargate</text>
+    </g>
+    <text x="260" y="445" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">ECS Fargate</text>
 
-    <line x1="290" y1="365" x2="430" y2="385" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <line x1="470" y1="365" x2="340" y2="385" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="260" y1="375" x2="400" y2="392" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="420" y1="375" x2="300" y2="392" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
 
     <!-- AWS Frontend Pipeline -->
     <rect x="40" y="475" width="530" height="250" rx="8" fill="#F0FFF0" stroke="#82B366" stroke-width="1.5"/>
     <text x="50" y="495" fill="#5B8C3E" font-family="Helvetica" font-size="12" font-weight="bold">Frontend Pipeline</text>
     <text x="260" y="495" fill="#5B8C3E" font-family="Helvetica" font-size="9">(path filter: frontend/**)</text>
 
-    <!-- Source -->
-    <rect x="60" y="515" width="120" height="55" rx="6" fill="#D5E8D4" stroke="#82B366" stroke-width="1.5"/>
-    <text x="120" y="538" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Source</text>
-    <text x="120" y="555" fill="#666666" font-family="Helvetica" font-size="9" text-anchor="middle">CodeStar</text>
-    <text x="120" y="565" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Connection</text>
+    <!-- FE Source icon -->
+    <g transform="translate(60,520)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#C7131F" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Code</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Star</text>
+    </g>
+    <text x="80" y="575" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Source</text>
 
-    <!-- Build -->
-    <rect x="220" y="515" width="320" height="55" rx="6" fill="#D5E8D4" stroke="#82B366" stroke-width="1.5"/>
-    <text x="380" y="533" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Build (CodeBuild)</text>
-    <text x="380" y="550" fill="#666666" font-family="Helvetica" font-size="9" text-anchor="middle">yarn install → yarn build → S3 Upload → CloudFront Invalidation</text>
-    <text x="380" y="565" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Env: VITE_AUTH0_*, VITE_API_BASE_URL from Terraform outputs</text>
+    <!-- FE Build icon -->
+    <g transform="translate(240,520)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#C7131F" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Code</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Build</text>
+    </g>
+    <text x="260" y="575" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Build (CodeBuild)</text>
+    <text x="320" y="575" fill="#666666" font-family="Helvetica" font-size="7">yarn build &#x2192; S3 Upload &#x2192; CF Invalidation</text>
 
     <!-- Arrow -->
-    <line x1="180" y1="542" x2="220" y2="542" stroke="#82B366" stroke-width="2" marker-end="url(#arrowhead)"/>
+    <line x1="100" y1="540" x2="240" y2="540" stroke="#82B366" stroke-width="2" marker-end="url(#arrowhead)"/>
 
-    <!-- Target boxes -->
-    <rect x="220" y="590" width="140" height="50" rx="6" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="1.5"/>
-    <text x="290" y="610" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">S3 Bucket</text>
-    <text x="290" y="625" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">dist/ uploaded</text>
+    <!-- FE Target: S3 -->
+    <g transform="translate(240,610)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#277116" stroke="none"/>
+      <text x="20" y="24" fill="#FFFFFF" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">S3</text>
+    </g>
+    <text x="260" y="663" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">S3 Bucket</text>
+    <text x="260" y="676" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">dist/ uploaded</text>
 
-    <rect x="400" y="590" width="140" height="50" rx="6" fill="#DAE8FC" stroke="#6C8EBF" stroke-width="1.5"/>
-    <text x="470" y="610" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">CloudFront</text>
-    <text x="470" y="625" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Cache Invalidated</text>
+    <!-- FE Target: CloudFront -->
+    <g transform="translate(400,610)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#8C4FFF" stroke="none"/>
+      <text x="20" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Front</text>
+    </g>
+    <text x="420" y="663" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">CloudFront</text>
+    <text x="420" y="676" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Cache Invalidated</text>
 
-    <line x1="290" y1="570" x2="290" y2="590" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <line x1="470" y1="570" x2="470" y2="590" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="260" y1="560" x2="260" y2="610" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="280" y1="560" x2="420" y2="610" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
 
     <!-- GitHub to AWS arrow -->
     <path d="M 530,125 L 300,125 L 300,195" fill="none" stroke="#FF9900" stroke-width="2"/>
@@ -133,106 +162,156 @@
     <rect x="640" y="195" width="530" height="265" rx="8" fill="#F0F8FF" stroke="#0078D4" stroke-width="1.5"/>
     <text x="650" y="215" fill="#0078D4" font-family="Helvetica" font-size="12" font-weight="bold">Backend Workflow (deploy-backend.yaml)</text>
 
-    <!-- Steps -->
-    <rect x="650" y="235" width="90" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="695" y="255" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Azure</text>
-    <text x="695" y="268" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle">Login</text>
-    <text x="695" y="280" fill="#2E75B6" font-family="Helvetica" font-size="7" text-anchor="middle">(OIDC)</text>
+    <!-- Azure Login icon -->
+    <g transform="translate(660,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Azure</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Login</text>
+      <text x="20" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">OIDC</text>
+    </g>
+    <text x="680" y="290" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Azure Login</text>
 
-    <rect x="760" y="235" width="90" height="50" rx="6" fill="#E1D5E7" stroke="#9673A6" stroke-width="1.5"/>
-    <text x="805" y="255" fill="#5B3D73" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Key Vault</text>
-    <text x="805" y="268" fill="#9673A6" font-family="Helvetica" font-size="8" text-anchor="middle">Fetch</text>
-    <text x="805" y="280" fill="#9673A6" font-family="Helvetica" font-size="7" text-anchor="middle">Secrets</text>
+    <!-- Key Vault icon -->
+    <g transform="translate(770,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#00A36C" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Key</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Vault</text>
+    </g>
+    <text x="790" y="290" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Key Vault</text>
+    <text x="790" y="303" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Fetch Secrets</text>
 
-    <rect x="870" y="235" width="90" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="915" y="255" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Docker</text>
-    <text x="915" y="268" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle">Build</text>
+    <!-- Docker Build icon -->
+    <g transform="translate(880,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Docker</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Build</text>
+    </g>
+    <text x="900" y="290" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Docker Build</text>
 
-    <rect x="980" y="235" width="90" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="1025" y="255" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">ACR</text>
-    <text x="1025" y="268" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle">Push</text>
-    <text x="1025" y="280" fill="#2E75B6" font-family="Helvetica" font-size="7" text-anchor="middle">:SHA + :latest</text>
+    <!-- ACR Push icon -->
+    <g transform="translate(990,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">ACR</text>
+      <text x="20" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Push</text>
+    </g>
+    <text x="1010" y="290" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">ACR Push</text>
+    <text x="1010" y="303" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">:SHA + :latest</text>
 
-    <rect x="1090" y="235" width="70" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="1125" y="255" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">App Svc</text>
-    <text x="1125" y="268" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle">Update</text>
-    <text x="1125" y="280" fill="#2E75B6" font-family="Helvetica" font-size="7" text-anchor="middle">+ Restart</text>
+    <!-- App Service Update icon -->
+    <g transform="translate(1100,235)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">App</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Service</text>
+      <text x="20" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Update</text>
+    </g>
+    <text x="1120" y="290" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">App Svc</text>
+    <text x="1120" y="303" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Update + Restart</text>
 
-    <!-- Arrows -->
-    <line x1="740" y1="260" x2="760" y2="260" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
-    <line x1="850" y1="260" x2="870" y2="260" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
-    <line x1="960" y1="260" x2="980" y2="260" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
-    <line x1="1070" y1="260" x2="1090" y2="260" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
+    <!-- Arrows between Azure BE stages -->
+    <line x1="700" y1="255" x2="770" y2="255" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
+    <line x1="810" y1="255" x2="880" y2="255" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
+    <line x1="920" y1="255" x2="990" y2="255" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
+    <line x1="1030" y1="255" x2="1100" y2="255" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowhead-azure)"/>
 
     <!-- Azure Backend detail -->
-    <rect x="650" y="305" width="510" height="50" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
-    <text x="905" y="322" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Key Vault secrets: ACR-NAME, IMAGE-NAME, BACKEND-WORKING-DIRECTORY,</text>
-    <text x="905" y="336" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">BACKEND-APP-SERVICE-NAME, RESOURCE-GROUP-NAME</text>
+    <rect x="650" y="310" width="510" height="50" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="905" y="327" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Key Vault secrets: ACR-NAME, IMAGE-NAME, BACKEND-WORKING-DIRECTORY,</text>
+    <text x="905" y="341" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">BACKEND-APP-SERVICE-NAME, RESOURCE-GROUP-NAME</text>
 
-    <!-- Target boxes -->
-    <rect x="870" y="375" width="130" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="935" y="395" fill="#1A4472" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">ACR</text>
-    <text x="935" y="412" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">Container Registry</text>
+    <!-- Azure BE Target boxes -->
+    <g transform="translate(880,380)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="18" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">ACR</text>
+      <text x="20" y="30" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Registry</text>
+    </g>
+    <text x="900" y="433" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">ACR</text>
 
-    <rect x="1030" y="375" width="130" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="1095" y="395" fill="#1A4472" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">App Service</text>
-    <text x="1095" y="412" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">Linux B1</text>
+    <g transform="translate(1050,380)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">App</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Service</text>
+    </g>
+    <text x="1070" y="433" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">App Service</text>
+    <text x="1070" y="446" fill="#2E75B6" font-family="Helvetica" font-size="8" text-anchor="middle">Linux B1</text>
 
-    <line x1="935" y1="355" x2="935" y2="375" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <line x1="1095" y1="355" x2="1095" y2="375" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="900" y1="360" x2="900" y2="380" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="1070" y1="360" x2="1070" y2="380" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
 
     <!-- Azure Frontend Pipeline -->
     <rect x="640" y="475" width="530" height="250" rx="8" fill="#F0FFF8" stroke="#00A36C" stroke-width="1.5"/>
     <text x="650" y="495" fill="#00563F" font-family="Helvetica" font-size="12" font-weight="bold">Frontend Workflow (deploy-frontend.yaml)</text>
 
-    <!-- Steps -->
-    <rect x="650" y="515" width="75" height="50" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
-    <text x="688" y="535" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Azure</text>
-    <text x="688" y="548" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle">Login</text>
-    <text x="688" y="560" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">(OIDC)</text>
+    <!-- Azure FE: Login icon -->
+    <g transform="translate(660,520)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Azure</text>
+      <text x="20" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Login</text>
+      <text x="20" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">OIDC</text>
+    </g>
+    <text x="680" y="575" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Azure Login</text>
 
-    <rect x="740" y="515" width="80" height="50" rx="6" fill="#E1D5E7" stroke="#9673A6" stroke-width="1.5"/>
-    <text x="780" y="535" fill="#5B3D73" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Key Vault</text>
-    <text x="780" y="548" fill="#9673A6" font-family="Helvetica" font-size="8" text-anchor="middle">Fetch</text>
-    <text x="780" y="560" fill="#9673A6" font-family="Helvetica" font-size="7" text-anchor="middle">Auth0 + Config</text>
+    <!-- Azure FE: Key Vault -->
+    <g transform="translate(760,520)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#00A36C" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Key</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Vault</text>
+    </g>
+    <text x="780" y="575" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Key Vault</text>
+    <text x="780" y="588" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Auth0 + Config</text>
 
-    <rect x="840" y="515" width="90" height="50" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
-    <text x="885" y="535" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Yarn</text>
-    <text x="885" y="548" fill="#00A36C" font-family="Helvetica" font-size="9" text-anchor="middle">Build</text>
-    <text x="885" y="560" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">Node 23.1</text>
+    <!-- Azure FE: Yarn Build -->
+    <rect x="850" y="525" width="70" height="35" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
+    <text x="885" y="540" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Yarn</text>
+    <text x="885" y="553" fill="#00A36C" font-family="Helvetica" font-size="8" text-anchor="middle">Build</text>
 
-    <rect x="950" y="515" width="90" height="50" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
-    <text x="995" y="535" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Blob</text>
-    <text x="995" y="548" fill="#00A36C" font-family="Helvetica" font-size="9" text-anchor="middle">Upload</text>
-    <text x="995" y="560" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">$web container</text>
+    <!-- Azure FE: Blob Upload -->
+    <g transform="translate(960,522)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Blob</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Upload</text>
+    </g>
+    <text x="980" y="575" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Blob Upload</text>
+    <text x="980" y="588" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">$web container</text>
 
-    <rect x="1060" y="515" width="100" height="50" rx="6" fill="#E6F4EA" stroke="#00A36C" stroke-width="1.5"/>
-    <text x="1110" y="535" fill="#00563F" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Front Door</text>
-    <text x="1110" y="548" fill="#00A36C" font-family="Helvetica" font-size="9" text-anchor="middle">Cache Purge</text>
-    <text x="1110" y="560" fill="#00A36C" font-family="Helvetica" font-size="7" text-anchor="middle">(async)</text>
+    <!-- Azure FE: Front Door -->
+    <g transform="translate(1070,522)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Front</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Door</text>
+    </g>
+    <text x="1090" y="575" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Front Door</text>
+    <text x="1090" y="588" fill="#666666" font-family="Helvetica" font-size="8" text-anchor="middle">Cache Purge</text>
 
-    <!-- Arrows -->
-    <line x1="725" y1="540" x2="740" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="820" y1="540" x2="840" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="930" y1="540" x2="950" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-    <line x1="1040" y1="540" x2="1060" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <!-- Azure FE arrows -->
+    <line x1="700" y1="540" x2="760" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="800" y1="540" x2="850" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="920" y1="540" x2="960" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+    <line x1="1000" y1="540" x2="1070" y2="540" stroke="#00A36C" stroke-width="1.5" marker-end="url(#arrowhead)"/>
 
     <!-- Azure Frontend detail -->
-    <rect x="650" y="585" width="510" height="40" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
-    <text x="905" y="602" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Key Vault secrets: AUTH0-CLIENT-ID, AUTH0-DOMAIN, AUTH0-AUDIENCE, API-BASE-URL,</text>
-    <text x="905" y="616" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">FRONTEND-STORAGE-ACCOUNT-NAME, FRONTDOOR-PROFILE-NAME, RESOURCE-GROUP-NAME</text>
+    <rect x="650" y="600" width="510" height="40" rx="4" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="905" y="617" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Key Vault secrets: AUTH0-CLIENT-ID, AUTH0-DOMAIN, AUTH0-AUDIENCE, API-BASE-URL,</text>
+    <text x="905" y="631" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">FRONTEND-STORAGE-ACCOUNT-NAME, FRONTDOOR-PROFILE-NAME, RESOURCE-GROUP-NAME</text>
 
-    <!-- Target boxes -->
-    <rect x="870" y="645" width="130" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="935" y="665" fill="#1A4472" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Storage Account</text>
-    <text x="935" y="682" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">$web (dist/)</text>
+    <!-- Azure FE Target boxes -->
+    <g transform="translate(880,660)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Storage</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Acct</text>
+    </g>
+    <text x="900" y="713" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Storage Account</text>
+    <text x="900" y="726" fill="#2E75B6" font-family="Helvetica" font-size="8" text-anchor="middle">$web (dist/)</text>
 
-    <rect x="1030" y="645" width="130" height="50" rx="6" fill="#BDD7EE" stroke="#2E75B6" stroke-width="1.5"/>
-    <text x="1095" y="665" fill="#1A4472" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Front Door</text>
-    <text x="1095" y="682" fill="#2E75B6" font-family="Helvetica" font-size="9" text-anchor="middle">CDN Cache</text>
+    <g transform="translate(1050,660)">
+      <rect x="0" y="0" width="40" height="40" rx="6" fill="#0078D4" stroke="none"/>
+      <text x="20" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Front</text>
+      <text x="20" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Door</text>
+    </g>
+    <text x="1070" y="713" fill="#1A4472" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Front Door</text>
+    <text x="1070" y="726" fill="#2E75B6" font-family="Helvetica" font-size="8" text-anchor="middle">CDN Cache</text>
 
-    <line x1="935" y1="625" x2="935" y2="645" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
-    <line x1="1095" y1="625" x2="1095" y2="645" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="900" y1="640" x2="900" y2="660" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="1070" y1="640" x2="1070" y2="660" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
 
     <!-- GitHub to Azure arrow -->
     <path d="M 670,125 L 900,125 L 900,195" fill="none" stroke="#0078D4" stroke-width="2"/>

--- a/docs/diagrams/gcp-architecture.drawio.svg
+++ b/docs/diagrams/gcp-architecture.drawio.svg
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1200" height="920" viewBox="-0.5 -0.5 1200 920" content="&lt;mxfile host=&quot;app.diagrams.net&quot;&gt;&lt;diagram name=&quot;GCP Architecture&quot; id=&quot;gcp-arch&quot;&gt;&lt;mxGraphModel dx=&quot;1200&quot; dy=&quot;920&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;1200&quot; pageHeight=&quot;920&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;&lt;root&gt;&lt;mxCell id=&quot;0&quot;/&gt;&lt;mxCell id=&quot;1&quot; parent=&quot;0&quot;/&gt;&lt;mxCell id=&quot;title&quot; value=&quot;Google Cloud Infrastructure Architecture&quot; style=&quot;text;html=1;fontSize=20;fontStyle=1;fillColor=none;align=center;verticalAlign=middle;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;300&quot; y=&quot;10&quot; width=&quot;600&quot; height=&quot;30&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;user&quot; value=&quot;User&quot; style=&quot;shape=mxgraph.aws4.client;whiteSpace=wrap;html=1;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;555&quot; y=&quot;50&quot; width=&quot;50&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;auth0&quot; value=&quot;Auth0&amp;#xa;JWT / OAuth2 / JWKS&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;fillColor=#f0f0f0;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;930&quot; y=&quot;50&quot; width=&quot;140&quot; height=&quot;50&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;gclb&quot; value=&quot;Cloud Load Balancing&amp;#xa;(External HTTPS LB)&amp;#xa;Cloud CDN Enabled&quot; style=&quot;shape=mxgraph.gcp2.external_https_load_balancer;fillColor=#4285F4;fontColor=#232F3E;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;556&quot; y=&quot;130&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;gcs&quot; value=&quot;Cloud Storage&amp;#xa;React SPA (Static Files)&quot; style=&quot;shape=mxgraph.gcp2.cloud_storage;fillColor=#4285F4;fontColor=#232F3E;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;146&quot; y=&quot;240&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;vpc&quot; value=&quot;VPC Network 10.0.0.0/16&quot; style=&quot;rounded=1;whiteSpace=wrap;html=1;container=1;collapsible=0;recursiveResize=0;fillColor=none;strokeColor=#4285F4;strokeWidth=2.5;dashed=0;verticalAlign=top;fontColor=#4285F4;fontStyle=1;fontSize=12;align=left;spacingLeft=10;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;340&quot; y=&quot;230&quot; width=&quot;830&quot; height=&quot;540&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cloudrun&quot; value=&quot;Cloud Run&amp;#xa;NestJS API (:3000)&amp;#xa;VPC Connector&quot; style=&quot;shape=mxgraph.gcp2.cloud_run;fillColor=#4285F4;fontColor=#232F3E;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;536&quot; y=&quot;460&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;cloudsql&quot; value=&quot;Cloud SQL&amp;#xa;PostgreSQL 16&amp;#xa;Private IP / Encrypted&quot; style=&quot;shape=mxgraph.gcp2.cloud_sql;fillColor=#4285F4;fontColor=#232F3E;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;855&quot; y=&quot;460&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;ar&quot; value=&quot;Artifact Registry&amp;#xa;Docker Repository&quot; style=&quot;shape=mxgraph.gcp2.artifact_registry;fillColor=#4285F4;fontColor=#232F3E;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;990&quot; y=&quot;310&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;sm&quot; value=&quot;Secret Manager&amp;#xa;DB URL / Auth0 Config&quot; style=&quot;shape=mxgraph.gcp2.secret_manager;fillColor=#4285F4;fontColor=#232F3E;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;990&quot; y=&quot;420&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;mxCell id=&quot;logging&quot; value=&quot;Cloud Logging&amp;#xa;Structured Logs&quot; style=&quot;shape=mxgraph.gcp2.cloud_logging;fillColor=#4285F4;fontColor=#232F3E;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=9;&quot; vertex=&quot;1&quot; parent=&quot;1&quot;&gt;&lt;mxGeometry x=&quot;990&quot; y=&quot;530&quot; width=&quot;48&quot; height=&quot;48&quot; as=&quot;geometry&quot;/&gt;&lt;/mxCell&gt;&lt;/root&gt;&lt;/mxGraphModel&gt;&lt;/diagram&gt;&lt;/mxfile&gt;">
+  <defs/>
+  <g>
+    <!-- Title -->
+    <text x="600" y="25" fill="#333333" font-family="Helvetica" font-size="20" text-anchor="middle" font-weight="bold">Google Cloud Infrastructure Architecture</text>
+
+    <!-- User -->
+    <g transform="translate(560,50)">
+      <ellipse cx="20" cy="10" rx="10" ry="10" fill="#FFFFFF" stroke="#333333" stroke-width="1.5"/>
+      <line x1="20" y1="20" x2="20" y2="35" stroke="#333333" stroke-width="1.5"/>
+      <line x1="10" y1="26" x2="30" y2="26" stroke="#333333" stroke-width="1.5"/>
+      <line x1="20" y1="35" x2="12" y2="48" stroke="#333333" stroke-width="1.5"/>
+      <line x1="20" y1="35" x2="28" y2="48" stroke="#333333" stroke-width="1.5"/>
+      <text x="20" y="63" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">User</text>
+    </g>
+
+    <!-- Auth0 -->
+    <rect x="920" y="50" width="140" height="45" rx="8" fill="#F5F5F5" stroke="#999999" stroke-width="1.5"/>
+    <text x="990" y="68" fill="#333333" font-family="Helvetica" font-size="13" text-anchor="middle" font-weight="bold">Auth0</text>
+    <text x="990" y="83" fill="#666666" font-family="Helvetica" font-size="10" text-anchor="middle">JWT / OAuth2 / JWKS</text>
+
+    <!-- Auth0 arrow from user -->
+    <line x1="600" y1="65" x2="920" y2="65" stroke="#999999" stroke-width="1" stroke-dasharray="6,3"/>
+    <polygon points="916,62 922,65 916,68" fill="#999999"/>
+    <text x="760" y="58" fill="#999999" font-family="Helvetica" font-size="9" text-anchor="middle">OAuth2 / JWT (RS256)</text>
+
+    <!-- Cloud Load Balancing + CDN icon -->
+    <g transform="translate(550,130)">
+      <rect x="0" y="0" width="60" height="48" rx="8" fill="#4285F4" stroke="none"/>
+      <text x="30" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Cloud LB</text>
+      <text x="30" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">External HTTPS</text>
+      <line x1="8" y1="32" x2="52" y2="32" stroke="#FFFFFF" stroke-width="0.5" stroke-opacity="0.5"/>
+      <text x="30" y="42" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Cloud CDN</text>
+    </g>
+    <text x="580" y="193" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Cloud Load Balancing</text>
+    <text x="580" y="207" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">External HTTPS LB + Cloud CDN</text>
+
+    <!-- User to Cloud LB arrow -->
+    <line x1="580" y1="115" x2="580" y2="130" stroke="#333333" stroke-width="2"/>
+    <polygon points="576,127 580,133 584,127" fill="#333333"/>
+    <text x="595" y="124" fill="#333333" font-family="Helvetica" font-size="9">HTTPS</text>
+
+    <!-- Cloud Storage icon -->
+    <g transform="translate(146,240)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#4285F4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Storage</text>
+      <rect x="10" y="32" width="28" height="8" rx="2" fill="#FFFFFF" fill-opacity="0.3" stroke="none"/>
+    </g>
+    <text x="170" y="303" fill="#333333" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">Cloud Storage</text>
+    <text x="170" y="317" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">React SPA (Static Files)</text>
+
+    <!-- Cloud LB to Storage arrow -->
+    <path d="M 550,154 L 320,154 L 320,264 L 194,264" fill="none" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="198,261 192,264 198,267" fill="#333333"/>
+    <text x="340" y="148" fill="#333333" font-family="Helvetica" font-size="9">/* (Backend Bucket)</text>
+
+    <!-- VPC Box -->
+    <rect x="340" y="230" width="830" height="560" rx="12" fill="none" stroke="#4285F4" stroke-width="2.5"/>
+    <rect x="350" y="230" width="230" height="22" rx="4" fill="#E8F0FE" stroke="none"/>
+    <g transform="translate(352,232)">
+      <rect x="0" y="0" width="18" height="18" rx="2" fill="#4285F4" stroke="none"/>
+      <text x="9" y="13" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">VPC</text>
+    </g>
+    <text x="378" y="246" fill="#4285F4" font-family="Helvetica" font-size="12" font-weight="bold">VPC Network 10.0.0.0/16</text>
+
+    <!-- Public Subnet -->
+    <rect x="370" y="270" width="380" height="130" rx="8" fill="#E8F0FE" stroke="#4285F4" stroke-width="1.5" fill-opacity="0.3"/>
+    <text x="380" y="288" fill="#4285F4" font-family="Helvetica" font-size="10" font-weight="bold">Public Subnet 10.0.1.0/24 (asia-northeast1)</text>
+
+    <!-- Cloud NAT icon -->
+    <g transform="translate(395,300)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#4285F4" stroke="none"/>
+      <text x="22" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="22" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">NAT</text>
+      <text x="22" y="38" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Router</text>
+    </g>
+    <text x="417" y="358" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle">Cloud NAT</text>
+    <text x="417" y="370" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">(Cloud Router)</text>
+
+    <!-- IAP icon -->
+    <g transform="translate(530,300)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#EA4335" stroke="none"/>
+      <text x="22" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="7" text-anchor="middle" font-weight="bold">IAP</text>
+      <text x="22" y="28" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Tunnel</text>
+    </g>
+    <text x="552" y="358" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle">IAP Tunnel</text>
+    <text x="552" y="370" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">(Bastion alternative)</text>
+
+    <!-- Cloud Armor icon -->
+    <g transform="translate(660,300)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#EA4335" stroke="none"/>
+      <text x="22" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="22" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Armor</text>
+      <text x="22" y="38" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">WAF</text>
+    </g>
+    <text x="682" y="358" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle">Cloud Armor</text>
+    <text x="682" y="370" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">(WAF / DDoS)</text>
+
+    <!-- Private Subnet / Serverless VPC Access -->
+    <rect x="370" y="420" width="780" height="350" rx="8" fill="#FEF7E0" stroke="#F9AB00" stroke-width="1.5" fill-opacity="0.3"/>
+    <text x="380" y="438" fill="#F9AB00" font-family="Helvetica" font-size="10" font-weight="bold">Private Subnet 10.0.2.0/24 + Serverless VPC Access Connector</text>
+
+    <!-- Serverless NEG / Internal LB label -->
+    <g transform="translate(400,460)">
+      <rect x="0" y="0" width="60" height="44" rx="6" fill="#4285F4" stroke="none"/>
+      <text x="30" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Serverless</text>
+      <text x="30" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">NEG</text>
+      <text x="30" y="38" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">Backend Svc</text>
+    </g>
+    <text x="430" y="519" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Serverless NEG</text>
+    <text x="430" y="532" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Backend Service</text>
+
+    <!-- Cloud LB to Serverless NEG arrow -->
+    <path d="M 604,154 L 750,154 L 750,410 L 430,410 L 430,460" fill="none" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="427,456 430,462 433,456" fill="#333333"/>
+    <text x="765" y="300" fill="#333333" font-family="Helvetica" font-size="9" transform="rotate(90,765,300)">/api/* (URL Map)</text>
+
+    <!-- Cloud Run icon -->
+    <g transform="translate(536,560)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#4285F4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Run</text>
+      <rect x="10" y="32" width="28" height="3" rx="1" fill="#FFFFFF" fill-opacity="0.4" stroke="none"/>
+      <rect x="10" y="38" width="20" height="3" rx="1" fill="#FFFFFF" fill-opacity="0.3" stroke="none"/>
+    </g>
+    <text x="560" y="623" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Cloud Run</text>
+    <text x="560" y="637" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">NestJS API (:3000)</text>
+    <text x="560" y="651" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">VPC Connector / Min: 0, Max: 10</text>
+
+    <!-- NEG to Cloud Run arrow -->
+    <line x1="440" y1="504" x2="536" y2="570" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="533,567 538,573 540,565" fill="#333333"/>
+    <text x="470" y="530" fill="#333333" font-family="Helvetica" font-size="9">:3000</text>
+
+    <!-- Cloud SQL icon -->
+    <g transform="translate(855,555)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#4285F4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="6" text-anchor="middle" font-weight="bold">SQL</text>
+      <text x="24" y="38" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">PostgreSQL</text>
+    </g>
+    <text x="879" y="618" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Cloud SQL</text>
+    <text x="879" y="632" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">PostgreSQL 16</text>
+    <text x="879" y="646" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Private IP / CMEK Encrypted</text>
+    <text x="879" y="660" fill="#555555" font-family="Helvetica" font-size="9" text-anchor="middle">Automatic Backups: 7d</text>
+
+    <!-- Cloud Run to Cloud SQL arrow -->
+    <line x1="584" y1="584" x2="855" y2="579" stroke="#333333" stroke-width="1.5"/>
+    <polygon points="851,576 857,579 851,582" fill="#333333"/>
+    <text x="720" y="573" fill="#333333" font-family="Helvetica" font-size="9">:5432 (Private IP)</text>
+
+    <!-- IAP to Cloud SQL arrow -->
+    <path d="M 552,350 L 552,410 L 879,410 L 879,555" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="876,551 879,557 882,551" fill="#999999"/>
+    <text x="730" y="405" fill="#999999" font-family="Helvetica" font-size="9">:5432 (IAP + Cloud SQL Proxy)</text>
+
+    <!-- Private Service Connect label -->
+    <rect x="700" y="555" width="130" height="40" rx="6" fill="#E8F0FE" stroke="#4285F4" stroke-width="1"/>
+    <text x="765" y="571" fill="#4285F4" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Private Service</text>
+    <text x="765" y="585" fill="#4285F4" font-family="Helvetica" font-size="8" text-anchor="middle">Connect (PSC)</text>
+
+    <!-- Artifact Registry icon -->
+    <g transform="translate(990,310)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#4285F4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Artifact</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Registry</text>
+      <rect x="10" y="32" width="28" height="8" rx="2" fill="#FFFFFF" fill-opacity="0.3" stroke="none"/>
+    </g>
+    <text x="1014" y="373" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Artifact Registry</text>
+    <text x="1014" y="387" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Docker Repository</text>
+
+    <!-- Artifact Registry to Cloud Run -->
+    <path d="M 990,340 L 900,340 L 900,584 L 584,584" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="588,581 582,584 588,587" fill="#999999"/>
+    <text x="910" y="460" fill="#999999" font-family="Helvetica" font-size="9" transform="rotate(90,910,460)">image pull</text>
+
+    <!-- Secret Manager icon -->
+    <g transform="translate(990,420)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#EA4335" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Secret</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Manager</text>
+      <rect x="14" y="32" width="20" height="8" rx="2" fill="#FFFFFF" fill-opacity="0.3" stroke="none"/>
+    </g>
+    <text x="1014" y="483" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Secret Manager</text>
+    <text x="1014" y="497" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">DB URL / Auth0 Config</text>
+    <text x="1014" y="509" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Deploy Config</text>
+
+    <!-- Secret Manager to Cloud Run -->
+    <path d="M 990,450 L 940,450 L 940,594 L 584,594" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="588,591 582,594 588,597" fill="#999999"/>
+    <text x="945" y="520" fill="#999999" font-family="Helvetica" font-size="9" transform="rotate(90,945,520)">secrets ref</text>
+
+    <!-- Cloud Logging icon -->
+    <g transform="translate(990,530)">
+      <rect x="0" y="0" width="48" height="48" rx="8" fill="#4285F4" stroke="none"/>
+      <text x="24" y="16" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="24" y="26" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Logging</text>
+      <rect x="8" y="32" width="32" height="3" rx="1" fill="#FFFFFF" fill-opacity="0.4" stroke="none"/>
+      <rect x="8" y="38" width="24" height="3" rx="1" fill="#FFFFFF" fill-opacity="0.3" stroke="none"/>
+    </g>
+    <text x="1014" y="593" fill="#333333" font-family="Helvetica" font-size="10" text-anchor="middle" font-weight="bold">Cloud Logging</text>
+    <text x="1014" y="607" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Structured Logs</text>
+    <text x="1014" y="619" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">+ Cloud Monitoring</text>
+
+    <!-- Cloud Run to Logging -->
+    <path d="M 584,600 L 630,600 L 630,660 L 1014,660 L 1014,578" fill="none" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="1011,582 1014,576 1017,582" fill="#999999"/>
+    <text x="820" y="653" fill="#999999" font-family="Helvetica" font-size="9">auto logging</text>
+
+    <!-- VPC Connector box -->
+    <rect x="490" y="690" width="200" height="35" rx="6" fill="#F5F5F5" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="590" y="712" fill="#666666" font-family="Helvetica" font-size="9" text-anchor="middle">Serverless VPC Access Connector (10.0.8.0/28)</text>
+
+    <!-- CI/CD Section -->
+    <rect x="15" y="340" width="170" height="330" rx="8" fill="none" stroke="#0F9D58" stroke-width="1.5" stroke-dasharray="5,3"/>
+    <text x="100" y="358" fill="#0F9D58" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">CI/CD (Cloud Build)</text>
+
+    <!-- Cloud Build Backend icon -->
+    <g transform="translate(58,380)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#4285F4" stroke="none"/>
+      <text x="22" y="14" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="22" y="24" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Build</text>
+      <text x="22" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">(Backend)</text>
+    </g>
+    <text x="80" y="438" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Cloud Build (BE)</text>
+    <text x="80" y="450" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">Docker Build &#x2192; AR Push</text>
+    <text x="80" y="460" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">&#x2192; Cloud Run Deploy</text>
+
+    <!-- Cloud Build Frontend icon -->
+    <g transform="translate(58,475)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#4285F4" stroke="none"/>
+      <text x="22" y="14" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Cloud</text>
+      <text x="22" y="24" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Build</text>
+      <text x="22" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">(Frontend)</text>
+    </g>
+    <text x="80" y="533" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Cloud Build (FE)</text>
+    <text x="80" y="545" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">yarn build &#x2192; GCS Upload</text>
+    <text x="80" y="555" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">&#x2192; CDN Cache Invalidation</text>
+
+    <!-- Service Account -->
+    <g transform="translate(58,570)">
+      <rect x="0" y="0" width="44" height="44" rx="6" fill="#EA4335" stroke="none"/>
+      <text x="22" y="14" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Service</text>
+      <text x="22" y="24" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle" font-weight="bold">Account</text>
+      <text x="22" y="36" fill="#FFFFFF" font-family="Helvetica" font-size="5" text-anchor="middle">WIF</text>
+    </g>
+    <text x="80" y="628" fill="#333333" font-family="Helvetica" font-size="9" text-anchor="middle" font-weight="bold">Service Account</text>
+    <text x="80" y="640" fill="#555555" font-family="Helvetica" font-size="8" text-anchor="middle">Workload Identity</text>
+    <text x="80" y="650" fill="#555555" font-family="Helvetica" font-size="7" text-anchor="middle">Federation (OIDC)</text>
+
+    <!-- GitHub -->
+    <rect x="30" y="655" width="140" height="40" rx="6" fill="#24292E" stroke="#24292E" stroke-width="1.5"/>
+    <text x="100" y="680" fill="#FFFFFF" font-family="Helvetica" font-size="11" text-anchor="middle" font-weight="bold">GitHub Repository</text>
+
+    <!-- Connections in CI/CD -->
+    <line x1="100" y1="655" x2="100" y2="620" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <polygon points="97,623 100,617 103,623" fill="#999999"/>
+
+    <line x1="80" y1="570" x2="80" y2="525" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <polygon points="77,528 80,522 83,528" fill="#999999"/>
+    <text x="95" y="548" fill="#999999" font-family="Helvetica" font-size="8">WIF</text>
+
+    <line x1="80" y1="475" x2="80" y2="430" stroke="#999999" stroke-width="1" stroke-dasharray="4,3"/>
+    <polygon points="77,433 80,427 83,433" fill="#999999"/>
+
+    <!-- Pipeline to GCS -->
+    <path d="M 170,497 L 220,497 L 220,264 L 194,264" fill="none" stroke="#0F9D58" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="198,261 192,264 198,262" fill="#0F9D58"/>
+    <text x="230" y="380" fill="#0F9D58" font-family="Helvetica" font-size="8" transform="rotate(-90,230,380)">upload dist/</text>
+
+    <!-- Pipeline to Artifact Registry -->
+    <path d="M 170,402 L 260,402 L 260,334 L 990,334" fill="none" stroke="#0F9D58" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="986,331 992,334 986,337" fill="#0F9D58"/>
+    <text x="610" y="328" fill="#0F9D58" font-family="Helvetica" font-size="8">docker push</text>
+
+    <!-- Pipeline to Secret Manager -->
+    <path d="M 170,415 L 280,415 L 280,444 L 990,444" fill="none" stroke="#EA4335" stroke-width="1" stroke-dasharray="5,3"/>
+    <polygon points="986,441 992,444 986,447" fill="#EA4335"/>
+    <text x="610" y="438" fill="#EA4335" font-family="Helvetica" font-size="8">fetch secrets</text>
+
+    <!-- Firewall Rules Legend -->
+    <rect x="15" y="830" width="550" height="35" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="25" y="845" fill="#333333" font-family="Helvetica" font-size="9" font-weight="bold">Firewall Rules / Security:</text>
+    <text x="25" y="857" fill="#555555" font-family="Helvetica" font-size="8">Cloud Armor (WAF) &#x2192; Cloud LB &#x2192; Serverless NEG &#x2192; Cloud Run (VPC Connector) &#x2192; Cloud SQL (Private IP) / IAP &#x2192; SQL Proxy</text>
+
+    <!-- Region Label -->
+    <text x="700" y="875" fill="#888888" font-family="Helvetica" font-size="11" font-style="italic">Region: asia-northeast1 (Tokyo)</text>
+
+    <!-- Legend -->
+    <rect x="580" y="830" width="580" height="60" rx="6" fill="#FAFAFA" stroke="#CCCCCC" stroke-width="1"/>
+    <rect x="595" y="842" width="24" height="14" rx="3" fill="#4285F4" stroke="none"/>
+    <text x="624" y="854" fill="#555555" font-family="Helvetica" font-size="9">GCP Service (Blue)</text>
+    <rect x="730" y="842" width="24" height="14" rx="3" fill="#EA4335" stroke="none"/>
+    <text x="759" y="854" fill="#555555" font-family="Helvetica" font-size="9">Security / Identity</text>
+    <rect x="850" y="842" width="24" height="14" rx="3" fill="#0F9D58" stroke="none"/>
+    <text x="879" y="854" fill="#555555" font-family="Helvetica" font-size="9">CI/CD</text>
+    <rect x="930" y="842" width="24" height="14" rx="3" fill="#F9AB00" stroke="none"/>
+    <text x="959" y="854" fill="#555555" font-family="Helvetica" font-size="9">Network</text>
+    <line x1="595" y1="868" x2="625" y2="868" stroke="#333333" stroke-width="1.5"/>
+    <text x="630" y="872" fill="#555555" font-family="Helvetica" font-size="9">Data Flow</text>
+    <line x1="730" y1="868" x2="760" y2="868" stroke="#999999" stroke-width="1" stroke-dasharray="5,3"/>
+    <text x="765" y="872" fill="#555555" font-family="Helvetica" font-size="9">Config / Deploy / Auxiliary</text>
+    <text x="920" y="872" fill="#888888" font-family="Helvetica" font-size="8" font-style="italic">* Icon colors follow Google Cloud brand guidelines</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- GCPインフラ構成図(`gcp-architecture.drawio.svg`)を新規作成
- 既存のAWS/Azure/CI-CD構成図のアイコンカラーを公式ブランドカラーに更新

## GCP サービスマッピング

| AWS | Azure | GCP |
|-----|-------|-----|
| CloudFront | Front Door | Cloud Load Balancing + Cloud CDN |
| S3 | Storage Account | Cloud Storage |
| ECS Fargate | App Service | Cloud Run |
| Aurora Serverless | PostgreSQL Flexible | Cloud SQL (PostgreSQL) |
| ECR | ACR | Artifact Registry |
| SSM Parameter Store | Key Vault | Secret Manager |
| CloudWatch Logs | Log Analytics | Cloud Logging |
| ALB (Internal) | - | Serverless NEG |
| NAT Gateway | - | Cloud NAT |
| Bastion (EC2) | - | IAP Tunnel |
| CodePipeline | GitHub Actions | Cloud Build |
| - | - | Cloud Armor (WAF/DDoS) |

## Test plan
- [ ] `gcp-architecture.drawio.svg` がブラウザで正常に表示されること
- [ ] Draw.ioで開いてmxfile XMLが正しくパースされること
- [ ] 既存3ファイル(AWS/Azure/CI-CD)が引き続き正常表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)