### PR TITLE
docs: iac/awsの各リソースに日本語コメントを追加

### DIFF
--- a/iac/aws/alb.tf
+++ b/iac/aws/alb.tf
@@ -1,3 +1,4 @@
+# 内部ALB: CloudFront(VPC Origin)からのリクエストを受けてECSタスクへ振り分け
 resource "aws_lb" "alb" {
   drop_invalid_header_fields = false
   enable_deletion_protection = false
@@ -21,6 +22,7 @@ resource "aws_lb" "alb" {
   }
 }
 
+# HTTPリスナー(80): 既定では404を返し、リスナールールにマッチしたものだけ転送する
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.alb.arn
   port              = 80
@@ -37,6 +39,7 @@ resource "aws_lb_listener" "http" {
   }
 }
 
+# リスナールール: /api/* パスのリクエストをECSサービス向けターゲットグループへ転送
 resource "aws_lb_listener_rule" "from_cloudfront" {
   listener_arn = aws_lb_listener.http.arn
   priority     = 1

--- a/iac/aws/aurora_serverless_v2.tf
+++ b/iac/aws/aurora_serverless_v2.tf
@@ -1,3 +1,4 @@
+# DBサブネットグループ: Auroraクラスタを配置する2AZのプライベートサブネット
 resource "aws_db_subnet_group" "db_subnet_group" {
   name = "${var.app-name}-${var.environment}"
   subnet_ids = [
@@ -6,12 +7,14 @@ resource "aws_db_subnet_group" "db_subnet_group" {
   ]
 }
 
+# DBマスターパスワード: 16桁のランダム文字列で自動生成
 resource "random_string" "db_password" {
   length           = 16
   special          = false
   override_special = "!#$&"
 }
 
+# DB接続文字列(DATABASE_URL)を組み立て: SSMパラメータに保存しECSタスクへ注入する
 locals {
   db_raw_password     = random_string.db_password.result
   db_encoded_password = urlencode(local.db_raw_password)
@@ -33,6 +36,9 @@ locals {
   )
 }
 
+# Aurora PostgreSQL Serverless v2 クラスタ
+# - 利用がない時間帯は自動で一時停止 (seconds_until_auto_pause)
+# - min_capacity=0 でゼロまでスケールダウン可能
 resource "aws_rds_cluster" "cluster" {
   cluster_identifier         = "${var.app-name}-${var.environment}-db-cluster"
   engine                     = "aurora-postgresql"
@@ -55,6 +61,7 @@ resource "aws_rds_cluster" "cluster" {
   skip_final_snapshot = true
 }
 
+# Serverless v2 のDBインスタンス(クラスタへ紐付ける実体)
 resource "aws_rds_cluster_instance" "instance" {
   identifier         = "${var.app-name}-${var.environment}-db-instance"
   cluster_identifier = aws_rds_cluster.cluster.id
@@ -63,6 +70,7 @@ resource "aws_rds_cluster_instance" "instance" {
   engine_version     = aws_rds_cluster.cluster.engine_version
 }
 
+# SSMパラメータストア(SecureString): DATABASE_URLをECSタスクのsecretsとして参照させる
 resource "aws_ssm_parameter" "db_connection_string" {
   data_type        = "text"
   name             = "/${var.environment}/connection_strings/${var.app-name}"

--- a/iac/aws/auth0.tf
+++ b/iac/aws/auth0.tf
@@ -1,3 +1,5 @@
+# Auth0アプリケーション(SPA): フロントエンドからの認証フロー用クライアント
+# - コールバック/ログアウト/Web Origin に CloudFront のドメインを許可
 resource "auth0_client" "app" {
   allowed_logout_urls = [
     "https://${aws_cloudfront_distribution.cdn.domain_name}",
@@ -23,6 +25,7 @@ resource "auth0_client" "app" {
   }
 }
 
+# Auth0 API(Resource Server): バックエンドが検証するアクセストークンのaudienceを定義
 resource "auth0_resource_server" "audience" {
   name        = "${var.app-name}-${var.environment}-aws-audience"
   identifier  = "https://${aws_cloudfront_distribution.cdn.domain_name}"

--- a/iac/aws/bastion.tf
+++ b/iac/aws/bastion.tf
@@ -1,3 +1,4 @@
+# Amazon Linux 2023 の最新AMIを動的に取得(踏み台EC2のベースイメージ)
 data "aws_ami" "amazon_linux_2023" {
   most_recent = true
   owners      = ["amazon"]
@@ -23,6 +24,7 @@ data "aws_ami" "amazon_linux_2023" {
   }
 }
 
+# 踏み台EC2: Session Manager経由でプライベートサブネット内のRDS等にアクセスする目的
 resource "aws_instance" "bastion" {
   ami                         = "ami-0292622b22bd52948"
   associate_public_ip_address = false
@@ -64,11 +66,13 @@ resource "aws_instance" "bastion" {
   timeouts {}
 }
 
+# 踏み台EC2に紐付けるインスタンスプロファイル(IAMロールのEC2へのアタッチ用)
 resource "aws_iam_instance_profile" "bastion" {
   name = "${var.environment}-bastion_profile"
   role = aws_iam_role.bastion.name
 }
 
+# 踏み台EC2用IAMロール(EC2サービスがAssume Role可)
 resource "aws_iam_role" "bastion" {
   assume_role_policy = jsonencode(
     {
@@ -93,6 +97,7 @@ resource "aws_iam_role" "bastion" {
   }
 }
 
+# Session Managerによる接続を可能にするためのAWS管理ポリシーをアタッチ
 resource "aws_iam_role_policy_attachment" "bastion_ssm_core" {
   role       = aws_iam_role.bastion.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"

--- a/iac/aws/cloudfront.tf
+++ b/iac/aws/cloudfront.tf
@@ -1,11 +1,14 @@
+# AWSが管理する標準キャッシュポリシー(高効率キャッシュ): フロント静的アセット用
 data "aws_cloudfront_cache_policy" "optimized" {
   name = "Managed-CachingOptimized"
 }
 
+# フロントエンド(S3オリジン)識別子
 locals {
   frontend_origin_id = "${var.app-name}-${var.environment}-frontend"
 }
 
+# Origin Access Control: CloudFrontからS3への署名付きアクセスを必須化
 resource "aws_cloudfront_origin_access_control" "oac" {
   description                       = null
   name                              = "${var.app-name}-${var.environment}-oac"
@@ -14,6 +17,10 @@ resource "aws_cloudfront_origin_access_control" "oac" {
   signing_protocol                  = "sigv4"
 }
 
+# CloudFrontディストリビューション: ユーザ向けの唯一のエンドポイント
+# - 既定ビヘイビアは S3(フロント) を返す
+# - /api/* は VPC Origin 経由で内部ALBへ転送
+# - 403 を index.html へリライト(SPAクライアントサイドルーティング対応)
 resource "aws_cloudfront_distribution" "cdn" {
   enabled         = true
   http_version    = "http2"
@@ -37,12 +44,14 @@ resource "aws_cloudfront_distribution" "cdn" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  # オリジン1: フロント配信用 S3 バケット
   origin {
     domain_name              = aws_s3_bucket.web.bucket_regional_domain_name
     origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
     origin_id                = local.frontend_origin_id
   }
 
+  # オリジン2: 内部ALB(VPC Origin経由)
   origin {
     domain_name = aws_lb.alb.dns_name
     origin_id   = local.backend_origin_id
@@ -52,6 +61,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
   }
 
+  # /api/* 用追加ビヘイビア: キャッシュ無効・全ヘッダ転送でAPI挙動を素通し
   ordered_cache_behavior {
     path_pattern             = var.api-base-path
     cache_policy_id          = data.aws_cloudfront_cache_policy.disabled.id
@@ -68,6 +78,7 @@ resource "aws_cloudfront_distribution" "cdn" {
       restriction_type = "none"
     }
   }
+  # SPAルーティング対応: S3で見つからない(403)場合は index.html を返す
   custom_error_response {
     error_caching_min_ttl = 10
     error_code            = 403
@@ -81,10 +92,12 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 }
 
+# バックエンド(ALBオリジン)識別子
 locals {
   backend_origin_id = "${var.app-name}-${var.environment}-backend"
 }
 
+# CloudFront VPC Origin: 内部ALB(internal=true)をCloudFrontオリジンとして利用するための仕組み
 resource "aws_cloudfront_vpc_origin" "alb" {
   vpc_origin_endpoint_config {
     name                   = local.backend_origin_id
@@ -100,10 +113,12 @@ resource "aws_cloudfront_vpc_origin" "alb" {
   }
 }
 
+# AWS管理のキャッシュ無効ポリシー: APIレスポンスのキャッシュを抑止
 data "aws_cloudfront_cache_policy" "disabled" {
   name = "Managed-CachingDisabled"
 }
 
+# AWS管理のオリジンリクエストポリシー: 全てのビューワヘッダ/Cookieをオリジンへ転送
 data "aws_cloudfront_origin_request_policy" "all_viewer" {
   name = "Managed-AllViewer"
 }

--- a/iac/aws/code-pipeline-backend.tf
+++ b/iac/aws/code-pipeline-backend.tf
@@ -1,3 +1,4 @@
+# CodePipelineのDeployステージで参照するファイル名 と ECSサービスARN
 locals {
   image-definition-file-name = "imagedefinitions.json"
   ecs_service_arn = format(
@@ -9,6 +10,7 @@ locals {
   )
 }
 
+# バックエンド用CodePipeline: GitHub Push → CodeBuild(Dockerビルド/ECR Push) → ECSデプロイ
 resource "aws_codepipeline" "backend" {
   execution_mode = "QUEUED"
   name           = "${var.app-name}-${var.environment}-backend"
@@ -113,6 +115,7 @@ resource "aws_codepipeline" "backend" {
 }
 
 
+# CodePipeline実行用IAMロール(自AWSアカウントからのみAssume可)
 resource "aws_iam_role" "backend-codepipeline" {
   assume_role_policy = jsonencode(
     {
@@ -141,6 +144,10 @@ resource "aws_iam_role" "backend-codepipeline" {
 }
 
 
+# CodePipelineロールにインラインで権限付与
+# - CodeBuildの起動 / ECRイメージ情報参照 / S3アーティファクト読み書き
+# - CodeStar Connections(GitHub)利用 / CloudWatch Logs / ECSデプロイ操作
+# - ECSタスク実行ロール・タスクロールに対するiam:PassRole
 resource "aws_iam_role_policy" "backend-codepipeline" {
   name = "inline-2"
   policy = jsonencode(
@@ -281,6 +288,7 @@ resource "aws_iam_role_policy" "backend-codepipeline" {
   role = aws_iam_role.backend-codepipeline.name
 }
 
+# バックエンドCodeBuildプロジェクト: Dockerイメージのビルド・ECRへのPush・imagedefinitions.json生成
 resource "aws_codebuild_project" "backend" {
   build_timeout      = 60
   name               = "${var.app-name}-${var.environment}-backend-codebuild"
@@ -351,6 +359,7 @@ resource "aws_codebuild_project" "backend" {
   }
 }
 
+# CodeBuild実行用IAMロール
 resource "aws_iam_role" "backend-codebuild" {
   assume_role_policy = jsonencode(
     {
@@ -373,6 +382,9 @@ resource "aws_iam_role" "backend-codebuild" {
   tags                 = {}
 }
 
+# CodeBuildロール用インラインポリシー
+# - ECR Push / GetAuthorizationToken
+# - CloudWatch Logs出力 / アーティファクトS3アクセス / テストレポート出力
 resource "aws_iam_role_policy" "backend-codebuild" {
   name = "inline-2"
   policy = jsonencode(

--- a/iac/aws/code-pipeline-frontend.tf
+++ b/iac/aws/code-pipeline-frontend.tf
@@ -1,8 +1,10 @@
+# CodePipelineのアーティファクト保管用S3バケット(frontend/backend共用)
 resource "aws_s3_bucket" "artifact" {
   bucket = "${var.app-name}-${var.environment}-artifact-${random_string.suffix.result}"
   tags   = {}
 }
 
+# アーティファクトバケットへのパブリックアクセスを全面ブロック
 resource "aws_s3_bucket_public_access_block" "artifact" {
   block_public_acls       = true
   block_public_policy     = true
@@ -11,6 +13,7 @@ resource "aws_s3_bucket_public_access_block" "artifact" {
   restrict_public_buckets = true
 }
 
+# フロントエンド用CodePipeline: GitHub Push → CodeBuild(Vite build → S3アップロード → CFインバリデーション)
 resource "aws_codepipeline" "frontend" {
   execution_mode = "QUEUED"
   name           = "${var.app-name}-${var.environment}-frontend"
@@ -93,6 +96,9 @@ resource "aws_codepipeline" "frontend" {
   }
 }
 
+# フロントエンドCodeBuildプロジェクト
+# - .envにAuth0/CloudFrontの値を埋め込んで yarn build → distをS3へ同期
+# - 最後にCloudFrontキャッシュをインバリデーション(/*)
 resource "aws_codebuild_project" "frontend" {
   badge_enabled      = false
   build_timeout      = 60
@@ -155,6 +161,7 @@ resource "aws_codebuild_project" "frontend" {
 }
 
 
+# フロントエンド用CodePipeline実行ロール
 resource "aws_iam_role" "codepipeline_frontend" {
   assume_role_policy = jsonencode(
     {
@@ -176,6 +183,7 @@ resource "aws_iam_role" "codepipeline_frontend" {
   tags                 = {}
 }
 
+# CodePipelineロール用ポリシー: CodeStar Connections利用 / アーティファクトPut / CodeBuild起動 / ログ出力
 resource "aws_iam_policy" "codepipeline_frontend" {
   description = null
   name        = "codepipeline-${var.app-name}-${var.environment}-frontend-policy"
@@ -228,12 +236,14 @@ resource "aws_iam_policy" "codepipeline_frontend" {
   tags = {}
 }
 
+# CodePipelineロールへポリシーをアタッチ
 resource "aws_iam_role_policy_attachment" "codepipeline_frontend" {
   role       = aws_iam_role.codepipeline_frontend.name
   policy_arn = aws_iam_policy.codepipeline_frontend.arn
 
 }
 
+# フロントエンドCodeBuild実行ロール
 resource "aws_iam_role" "codebuild_frontend" {
   assume_role_policy = jsonencode(
     {
@@ -254,6 +264,10 @@ resource "aws_iam_role" "codebuild_frontend" {
   tags = {}
 }
 
+# CodeBuildロール用ポリシー:
+# - CloudWatch Logs出力 / テストレポート出力
+# - アーティファクトS3の読み込み / Webバケット(S3)への書き込み
+# - CloudFrontのインバリデーション実行
 resource "aws_iam_policy" "codebuild_frontend" {
   description = null
   name        = "codebuild-${var.app-name}-${var.environment}-frontend-policy"
@@ -305,6 +319,7 @@ resource "aws_iam_policy" "codebuild_frontend" {
   tags = {}
 }
 
+# CodeBuildロールへポリシーをアタッチ
 resource "aws_iam_role_policy_attachment" "codebuild_frontend" {
   role       = aws_iam_role.codebuild_frontend.name
   policy_arn = aws_iam_policy.codebuild_frontend.arn

--- a/iac/aws/ecr.tf
+++ b/iac/aws/ecr.tf
@@ -1,3 +1,4 @@
+# バックエンドDockerイメージを保管するECRリポジトリ(プッシュ時に脆弱性スキャン実行)
 resource "aws_ecr_repository" "backend" {
   name                 = "${var.environment}/${var.app-name}-backend"
   image_tag_mutability = "MUTABLE"

--- a/iac/aws/ecs.tf
+++ b/iac/aws/ecs.tf
@@ -1,3 +1,4 @@
+# ALBターゲットグループ: ECSタスク(FARGATE/IP)を対象にヘルスチェックする
 resource "aws_lb_target_group" "to_ecs_service" {
   deregistration_delay          = "300"
   load_balancing_algorithm_type = "round_robin"
@@ -27,16 +28,21 @@ resource "aws_lb_target_group" "to_ecs_service" {
   }
 }
 
+# ECSクラスタ: バックエンドAPIタスクを動かす論理境界
 resource "aws_ecs_cluster" "cluster" {
   name = "${var.app-name}-${var.environment}-cluster"
   tags = {}
 }
 
+# CloudWatch Logsロググループ: ECSコンテナの標準出力を集約(保持7日)
 resource "aws_cloudwatch_log_group" "backend" {
   name              = "/ecs/${var.app-name}-${var.environment}-log"
   retention_in_days = 7
 }
 
+# ECSタスク定義: Fargate上で動作するバックエンドコンテナの仕様
+# - 環境変数: Auth0/CORS/ログレベル等
+# - secrets: DATABASE_URL を SSM SecureString から注入
 resource "aws_ecs_task_definition" "task_definition" {
   container_definitions = jsonencode(
     [
@@ -122,6 +128,7 @@ resource "aws_ecs_task_definition" "task_definition" {
 }
 
 
+# ECSタスクロール: コンテナアプリ自身がAWSサービスを呼ぶときに引き受けるロール
 resource "aws_iam_role" "ecs_task" {
   assume_role_policy = jsonencode(
     {
@@ -144,6 +151,7 @@ resource "aws_iam_role" "ecs_task" {
   tags        = {}
 }
 
+# ECSタスク実行ロール: ECSエージェントがイメージ取得・SSM参照・ログ出力に使うロール
 resource "aws_iam_role" "execute_ecs_task" {
   assume_role_policy = jsonencode(
     {
@@ -166,6 +174,10 @@ resource "aws_iam_role" "execute_ecs_task" {
 }
 
 
+# タスク実行ロール用インラインポリシー
+# - ECR: バックエンドイメージのプル関連権限
+# - SSM: DATABASE_URLのSecureString取得
+# - KMS: SecureStringの復号
 resource "aws_iam_role_policy" "execute_ecs_task" {
   name = "inline-2"
   policy = jsonencode(
@@ -207,11 +219,14 @@ resource "aws_iam_role_policy" "execute_ecs_task" {
   role = aws_iam_role.execute_ecs_task.name
 }
 
+# AWS管理ポリシー(ECSタスク実行に必要な標準権限)をアタッチ
 resource "aws_iam_role_policy_attachment" "managed-ECSTaskExecutionRolePolicy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
   role       = aws_iam_role.execute_ecs_task.name
 }
 
+# ECSサービス: タスク定義を1コピー以上維持し、ALBターゲットグループに自動登録
+# - task_definition の変更は CodePipeline 経由で行うため lifecycle で無視
 resource "aws_ecs_service" "service" {
   cluster                            = aws_ecs_cluster.cluster.arn
   deployment_maximum_percent         = 200

--- a/iac/aws/provider.tf
+++ b/iac/aws/provider.tf
@@ -1,13 +1,16 @@
+# AWSプロバイダ: 東京リージョン(ap-northeast-1)を既定とする
 provider "aws" {
   region = "ap-northeast-1"
 }
 
+# Auth0プロバイダ: テナント情報を環境変数(terraform.tfvars)から注入
 provider "auth0" {
   domain        = var.auth0_domain
   client_id     = var.auth0_client_id
   client_secret = var.auth0_client_secret
 }
 
+# Terraform本体とプロバイダのバージョン固定
 terraform {
   required_version = ">= 1.13.5"
   required_providers {

--- a/iac/aws/s3.tf
+++ b/iac/aws/s3.tf
@@ -1,8 +1,10 @@
+# 静的Webアセット配信用S3バケット(CloudFront経由でのみ公開)
 resource "aws_s3_bucket" "web" {
   bucket = "${var.app-name}-${var.environment}-web-${random_string.suffix.result}"
   tags   = {}
 }
 
+# パブリックアクセス全面ブロック(誤った公開設定を防ぐ)
 resource "aws_s3_bucket_public_access_block" "web" {
   block_public_acls       = true
   block_public_policy     = true
@@ -11,6 +13,7 @@ resource "aws_s3_bucket_public_access_block" "web" {
   restrict_public_buckets = true
 }
 
+# バージョニング無効化(本テンプレートではロールバック運用しないため)
 resource "aws_s3_bucket_versioning" "web" {
   bucket = aws_s3_bucket.web.bucket
 
@@ -19,6 +22,7 @@ resource "aws_s3_bucket_versioning" "web" {
   }
 }
 
+# バケットポリシー: CloudFrontディストリビューションからのGetObjectのみ許可
 resource "aws_s3_bucket_policy" "web" {
   bucket = aws_s3_bucket.web.bucket
   policy = jsonencode(

--- a/iac/aws/security-group.tf
+++ b/iac/aws/security-group.tf
@@ -1,3 +1,4 @@
+# ALB用SG: 内部ALBに割り当て(インバウンドはCloudFront VPC Originからのみ許可)
 resource "aws_security_group" "alb" {
   name = "${var.app-name}-${var.environment}-internal-alb"
   tags = {
@@ -6,6 +7,7 @@ resource "aws_security_group" "alb" {
   vpc_id = aws_vpc.vpc.id
 }
 
+# ALBアウトバウンド: 全外向け通信を許可(ECSへの転送等)
 resource "aws_security_group_rule" "alb_out" {
   security_group_id = aws_security_group.alb.id
   type              = "egress"
@@ -15,6 +17,7 @@ resource "aws_security_group_rule" "alb_out" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+# ECSサービス用SG
 resource "aws_security_group" "ecs_service" {
   name = "${var.app-name}-${var.environment}-ecs-service"
   tags = {
@@ -24,6 +27,7 @@ resource "aws_security_group" "ecs_service" {
   timeouts {}
 }
 
+# ECSインバウンド: ALBからAPI公開ポート(例:3000)のみ許可
 resource "aws_security_group_rule" "ecs_service_in_alb" {
   security_group_id        = aws_security_group.ecs_service.id
   type                     = "ingress"
@@ -34,6 +38,7 @@ resource "aws_security_group_rule" "ecs_service_in_alb" {
   description              = "internal ALB target group"
 }
 
+# ECSアウトバウンド: 全外向け通信を許可(NAT経由のSaaS呼び出し等)
 resource "aws_security_group_rule" "ecs_service_out" {
   security_group_id = aws_security_group.ecs_service.id
   type              = "egress"
@@ -43,6 +48,8 @@ resource "aws_security_group_rule" "ecs_service_out" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+# CloudFront VPC Origin専用の管理SGを参照(VPC Origin作成時にAWSが自動生成)
+# このSGからのトラフィックだけをALBに通すために利用
 data "aws_security_group" "cloudfront_vpc_origin" {
   filter {
     name   = "group-name"
@@ -55,6 +62,7 @@ data "aws_security_group" "cloudfront_vpc_origin" {
   depends_on = [aws_cloudfront_vpc_origin.alb]
 }
 
+# ALBインバウンド: CloudFront VPC OriginのSGからのHTTP(80)のみ許可
 resource "aws_security_group_rule" "alb_in" {
   security_group_id        = aws_security_group.alb.id
   type                     = "ingress"
@@ -65,6 +73,8 @@ resource "aws_security_group_rule" "alb_in" {
   description              = "CloudFront VPC Origin http"
 }
 
+
+# DB(Aurora)用SG
 resource "aws_security_group" "db" {
   name = "${var.app-name}-${var.environment}-db"
   tags = {
@@ -75,6 +85,7 @@ resource "aws_security_group" "db" {
 }
 
 
+# DBインバウンド: ECSサービスからのPostgreSQL(5432)接続を許可
 resource "aws_security_group_rule" "db_in_ecs_service" {
   security_group_id        = aws_security_group.db.id
   type                     = "ingress"
@@ -86,6 +97,7 @@ resource "aws_security_group_rule" "db_in_ecs_service" {
 }
 
 
+# DBインバウンド: 踏み台EC2からのPostgreSQL(5432)接続を許可(運用時のメンテ用)
 resource "aws_security_group_rule" "db_in_bastion" {
   security_group_id        = aws_security_group.db.id
   type                     = "ingress"
@@ -97,6 +109,7 @@ resource "aws_security_group_rule" "db_in_bastion" {
 }
 
 
+# DBアウトバウンド: 全外向け許可
 resource "aws_security_group_rule" "db_out" {
   security_group_id = aws_security_group.db.id
   type              = "egress"
@@ -106,6 +119,7 @@ resource "aws_security_group_rule" "db_out" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+# 踏み台EC2用SG
 resource "aws_security_group" "bastion" {
   description = "bastion"
   name        = "${var.environment}-${var.app-name}-bastion"
@@ -116,6 +130,8 @@ resource "aws_security_group" "bastion" {
   timeouts {}
 }
 
+# 踏み台インバウンド: 開発者ローカルPCのIPからのみ全ポート許可
+# (Session Manager運用が前提のため通常は不要だが、ポートフォワード補助用)
 resource "aws_security_group_rule" "bastion_in_mypc" {
   security_group_id = aws_security_group.bastion.id
   type              = "ingress"
@@ -126,6 +142,7 @@ resource "aws_security_group_rule" "bastion_in_mypc" {
   description       = "my pc"
 }
 
+# 踏み台アウトバウンド: 全外向け許可(SSMエンドポイント・DB等への通信用)
 resource "aws_security_group_rule" "bastion_out" {
   security_group_id = aws_security_group.bastion.id
   type              = "egress"
@@ -136,6 +153,7 @@ resource "aws_security_group_rule" "bastion_out" {
 }
 
 
+# SSM用VPCエンドポイント向けSG(Session Manager等のためのインターフェイスエンドポイントに付与)
 resource "aws_security_group" "ssm" {
   description = "ssm"
   name        = "${var.environment}-${var.app-name}-ssm"
@@ -146,6 +164,7 @@ resource "aws_security_group" "ssm" {
   timeouts {}
 }
 
+# SSMエンドポイントへのインバウンド: VPC内部からのHTTPS(443)のみ許可
 resource "aws_security_group_rule" "ssm_in" {
   security_group_id = aws_security_group.ssm.id
   type              = "ingress"
@@ -156,6 +175,7 @@ resource "aws_security_group_rule" "ssm_in" {
   description       = "ssm"
 }
 
+# SSMエンドポイントSGからのアウトバウンド: 全許可
 resource "aws_security_group_rule" "ssm_out" {
   security_group_id = aws_security_group.ssm.id
   type              = "egress"

--- a/iac/aws/variables.tf
+++ b/iac/aws/variables.tf
@@ -16,11 +16,11 @@ variable "codestar-connection-arn" {
   description = "【環境変数で指定】接続のarn"
 }
 
-## AWSアカウントIDとリージョンの変数
+## AWSアカウントIDとリージョンの変数(実行中のAWS環境から自動取得)
 data "aws_caller_identity" "self" {}
 data "aws_region" "current" {}
 
-## アプリ名と環境
+## アプリ名と環境(各リソース名のプレフィックスとして利用)
 variable "app-name" {
   default = "sandbox-aws"
 }
@@ -39,7 +39,7 @@ variable "target-branch" {
   description = "このブランチにPushされたときにCodePipelineをトリガー"
 }
 
-## S3のバケット名をユニークにするための乱数
+## S3のバケット名をユニークにするための乱数(グローバル一意制約への対応)
 resource "random_string" "suffix" {
   length  = 5
   upper   = false
@@ -53,17 +53,21 @@ variable "backend-src-root" {
   description = "backendのルートパス"
 }
 
+# VPCに割り当てるCIDRブロック
 variable "vpc_cidr_block" {
   default = "172.16.0.0/16"
 }
+# パブリックサブネット(AZ-1a)のCIDR
 variable "subnet_public1a_cidr_block" {
   default = "172.16.1.0/24"
 }
 
+# プライベートサブネット(AZ-1a)のCIDR
 variable "subnet_private1a_cidr_block" {
   default = "172.16.2.0/24"
 }
 
+# プライベートサブネット(AZ-1c)のCIDR
 variable "subnet_private1c_cidr_block" {
   default = "172.16.3.0/24"
 }

--- a/iac/aws/vpc.tf
+++ b/iac/aws/vpc.tf
@@ -1,3 +1,4 @@
+# アプリ全体を収容するVPC(DNSホスト名/解決を有効化してエンドポイント名前解決を許可)
 resource "aws_vpc" "vpc" {
   assign_generated_ipv6_cidr_block = false
   cidr_block                       = var.vpc_cidr_block
@@ -8,6 +9,7 @@ resource "aws_vpc" "vpc" {
   }
 }
 
+# インターネットゲートウェイ: パブリックサブネットから外部へ抜けるための出口
 resource "aws_internet_gateway" "gw" {
   tags = {
     "Name" = "${var.app-name}-${var.environment}"
@@ -15,6 +17,7 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.vpc.id
 }
 
+# パブリックサブネット(AZ-1a): NAT GatewayなどIGW経由で外部公開するリソースを配置
 resource "aws_subnet" "public1a" {
   availability_zone = "${data.aws_region.current.region}a"
   cidr_block        = var.subnet_public1a_cidr_block
@@ -24,6 +27,7 @@ resource "aws_subnet" "public1a" {
   vpc_id = aws_vpc.vpc.id
 }
 
+# プライベートサブネット(AZ-1a): ECS / RDS / Bastion等の内部リソース配置先
 resource "aws_subnet" "private1a" {
   availability_zone = "${data.aws_region.current.region}a"
   cidr_block        = var.subnet_private1a_cidr_block
@@ -33,6 +37,7 @@ resource "aws_subnet" "private1a" {
   vpc_id = aws_vpc.vpc.id
 }
 
+# プライベートサブネット(AZ-1c): マルチAZ構成のためAZ-cにも同様のプライベートサブネットを用意
 resource "aws_subnet" "private1c" {
   availability_zone = "${data.aws_region.current.region}c"
   cidr_block        = var.subnet_private1c_cidr_block
@@ -42,6 +47,7 @@ resource "aws_subnet" "private1c" {
   vpc_id = aws_vpc.vpc.id
 }
 
+# Elastic IP: NAT Gatewayに割り当てる固定パブリックIP
 resource "aws_eip" "nat" {
   tags = {
     "Name" = "${var.app-name}-${var.environment}-nat-eip"
@@ -49,6 +55,7 @@ resource "aws_eip" "nat" {
   domain = "vpc"
 }
 
+# NAT Gateway: プライベートサブネットからのインターネット向け通信を中継
 resource "aws_nat_gateway" "nat" {
   allocation_id = aws_eip.nat.id
   subnet_id     = aws_subnet.public1a.id
@@ -57,6 +64,7 @@ resource "aws_nat_gateway" "nat" {
   }
 }
 
+# パブリック用ルートテーブル(IGW向け)
 resource "aws_route_table" "custom" {
   tags = {
     "Name" = "${var.app-name}-${var.environment}-public"
@@ -64,12 +72,14 @@ resource "aws_route_table" "custom" {
   vpc_id = aws_vpc.vpc.id
 }
 
+# パブリックルート: 0.0.0.0/0 を Internet Gateway 経由で外に出す
 resource "aws_route" "custom" {
   route_table_id         = aws_route_table.custom.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.gw.id
 }
 
+# プライベート用ルートテーブル(NAT Gateway向け)
 resource "aws_route_table" "main" {
   tags = {
     "Name" = "${var.app-name}-${var.environment}-private"
@@ -77,6 +87,7 @@ resource "aws_route_table" "main" {
   vpc_id = aws_vpc.vpc.id
 }
 
+# プライベートルート: 0.0.0.0/0 を NAT Gateway 経由で外に出す
 resource "aws_route" "main" {
   route_table_id         = aws_route_table.main.id
   destination_cidr_block = "0.0.0.0/0"
@@ -84,20 +95,24 @@ resource "aws_route" "main" {
 }
 
 
+# パブリックサブネット(1a)へパブリックルートテーブルを関連付け
 resource "aws_route_table_association" "public1a" {
   route_table_id = aws_route_table.custom.id
   subnet_id      = aws_subnet.public1a.id
 }
 
+# プライベートサブネット(1a)へプライベートルートテーブルを関連付け
 resource "aws_route_table_association" "private1a" {
   route_table_id = aws_route_table.main.id
   subnet_id      = aws_subnet.private1a.id
 }
+# プライベートサブネット(1c)へプライベートルートテーブルを関連付け
 resource "aws_route_table_association" "private1c" {
   route_table_id = aws_route_table.main.id
   subnet_id      = aws_subnet.private1c.id
 }
 
+# VPCのメインルートテーブルをプライベート用に上書き(デフォルト動作を内部寄りに)
 resource "aws_main_route_table_association" "main" {
   vpc_id         = aws_vpc.vpc.id
   route_table_id = aws_route_table.main.id

--- a/iac/aws/vpc_endpoint.tf
+++ b/iac/aws/vpc_endpoint.tf
@@ -1,3 +1,5 @@
+# SSM用VPCインターフェイスエンドポイント
+# プライベートサブネット内の踏み台EC2が、NAT/IGWを経由せずにSession Managerへ接続するため
 resource "aws_vpc_endpoint" "ssm" {
   ip_address_type = "ipv4"
   policy = jsonencode(
@@ -31,6 +33,7 @@ resource "aws_vpc_endpoint" "ssm" {
   timeouts {}
 }
 
+# Session Managerのメッセージ通信用VPCエンドポイント(SSM Agentが利用)
 resource "aws_vpc_endpoint" "ssmmessages" {
   ip_address_type = "ipv4"
   policy = jsonencode(
@@ -64,6 +67,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   timeouts {}
 }
 
+# EC2 MessagesのVPCエンドポイント(SSM AgentがEC2 APIメッセージのやりとりに使用)
 resource "aws_vpc_endpoint" "ec2messages" {
   ip_address_type = "ipv4"
   policy = jsonencode(


### PR DESCRIPTION
## Summary
- `iac/aws/` 配下の各 `.tf` ファイルのリソース/データソース宣言の直前に、役割と意図を説明する日本語コメントを追加
- 設定値の自明な説明ではなく、**構成上のポイント**(例: ALBが`internal=true`である理由、CloudFrontの `403 → /index.html` リライトがSPA対応であること、ECSタスク実行ロールがSSMパラメータ復号に使われる目的、など)を補足
- 既存の日本語コメント(`bastion.tf`の `SSM Agentを確実に起動` 等)は残し、既存スタイルと整合

## 変更ファイル(15)
- alb.tf / aurora_serverless_v2.tf / auth0.tf / bastion.tf / cloudfront.tf
- code-pipeline-backend.tf / code-pipeline-frontend.tf
- ecr.tf / ecs.tf / provider.tf / s3.tf / security-group.tf
- variables.tf / vpc.tf / vpc_endpoint.tf

## 変更内容
コメント追加のみで、リソース定義・パラメータ・依存関係には一切変更なし(+129 / -3 行)。

## Test plan
- [ ] `terraform fmt -check` で整形差分が出ないこと(確認済み: 差分なし)
- [ ] `terraform validate` がパスすること
- [ ] 既存リソースのプラン差分が出ないこと(`terraform plan` で no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)