### PR TITLE
docs: 運用・調査コマンドリファレンスを追加、READMEから移動

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ terraform init && terraform apply
 | [AWS構成図](./docs/diagrams/aws-architecture.drawio.svg) | AWS インフラ構成図 (Draw.io SVG) |
 | [Azure構成図](./docs/diagrams/azure-architecture.drawio.svg) | Azure インフラ構成図 (Draw.io SVG) |
 | [CI/CDパイプライン図](./docs/diagrams/cicd-pipeline.drawio.svg) | AWS/Azure CI/CD 比較図 (Draw.io SVG) |
+| [運用・調査コマンド](./docs/operations.md) | CloudWatch Logs・Athena・ECSヘルスチェック等の調査用コマンド集 |
 
 ## 正誤表
 
@@ -121,46 +122,4 @@ terraform init && terraform apply
 
 ## コマンドリファレンス
 
-### AWS - MFAトークン取得 (PowerShell)
-
-```powershell
-$mfa_device='[識別子]'
-
-$Env:AWS_ACCESS_KEY_ID=''
-$Env:AWS_SECRET_ACCESS_KEY=''
-$Env:AWS_SESSION_TOKEN=''
-
-$token=Read-Host
-$cre=(aws sts get-session-token --serial-number $mfa_device --token-code $token) | ConvertFrom-Json
-
-$Env:AWS_ACCESS_KEY_ID=$cre.Credentials.AccessKeyId
-$Env:AWS_SECRET_ACCESS_KEY=$cre.Credentials.SecretAccessKey
-$Env:AWS_SESSION_TOKEN=$cre.Credentials.SessionToken
-```
-
-### AWS - リソース削除
-
-```powershell
-# S3バケットを空にする (バケット名は実際のものに変更)
-aws s3 rm s3://sandbox-aws-dev-artifact-xxxxx --recursive
-aws s3 rm s3://sandbox-aws-dev-web-xxxxx --recursive
-
-# ECRリポジトリを空にする
-$repositoryName = "dev/sandbox-aws-backend"
-$imageList = aws ecr list-images --repository-name $repositoryName --query "imageIds[*]" --output json | ConvertFrom-Json
-foreach ($image in $imageList) {
-    $imageDigest = $image.imageDigest
-    $imageTag = $image.imageTag
-    $imageId = @{}
-    if ($imageDigest) { $imageId["imageDigest"] = $imageDigest }
-    if ($imageTag) { $imageId["imageTag"] = $imageTag }
-    aws ecr batch-delete-image --repository-name $repositoryName --image-ids (ConvertTo-Json @($imageId))
-}
-```
-
-### Docker
-
-```bash
-docker build -t sandbox-backend -f ./Dockerfile .
-docker run -p 3000:3000 -e LOG_LEVEL=error sandbox-backend:latest
-```
+MFA認証・リソース削除・調査コマンド等は [運用・調査コマンドリファレンス](./docs/operations.md) を参照してください。

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,157 @@
+# 運用・調査コマンドリファレンス
+
+調査・デバッグ時に使用するコマンド集です。
+`<AWSアカウントID>` / `<バケット名>` 等のプレースホルダは実際の値に置き換えて実行してください。
+
+---
+
+## AWS認証
+
+```powershell
+# 指定プロファイルの認証情報を環境変数に反映
+aws configure export-credentials --profile <プロファイル名> --format powershell | Invoke-Expression
+```
+
+### MFAトークン取得
+
+```powershell
+$mfa_device='[識別子]'
+
+$Env:AWS_ACCESS_KEY_ID=''
+$Env:AWS_SECRET_ACCESS_KEY=''
+$Env:AWS_SESSION_TOKEN=''
+
+$token=Read-Host
+$cre=(aws sts get-session-token --serial-number $mfa_device --token-code $token) | ConvertFrom-Json
+
+$Env:AWS_ACCESS_KEY_ID=$cre.Credentials.AccessKeyId
+$Env:AWS_SECRET_ACCESS_KEY=$cre.Credentials.SecretAccessKey
+$Env:AWS_SESSION_TOKEN=$cre.Credentials.SessionToken
+```
+
+---
+
+## CloudWatch Logs - ECSログ取得
+
+指定時刻の前後10分のECSログを取得します。
+
+```powershell
+$baseTime = [DateTimeOffset]::Parse("2026-05-09T15:54:25+09:00")
+$startTime = $baseTime.AddMinutes(-10).ToUnixTimeMilliseconds()
+$endTime = $baseTime.ToUnixTimeMilliseconds()
+
+aws logs filter-log-events `
+  --log-group-name /ecs/sandbox-aws-dev-log `
+  --start-time $startTime `
+  --end-time $endTime `
+  | ConvertFrom-Json `
+  | Select-Object -ExpandProperty events `
+  | ForEach-Object {
+      [PSCustomObject]@{
+          timestamp = [DateTimeOffset]::FromUnixTimeMilliseconds($_.timestamp).ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")
+          message   = $_.message
+      }
+  } `
+  | Format-List
+```
+
+---
+
+## Athena - ALBアクセスログ分析
+
+### テーブル作成
+
+```sql
+CREATE EXTERNAL TABLE alb_logs (
+  type string,
+  time string,
+  elb string,
+  client_ip string,
+  client_port int,
+  target_ip string,
+  target_port int,
+  request_processing_time double,
+  target_processing_time double,
+  response_processing_time double,
+  elb_status_code int,
+  target_status_code string,
+  received_bytes bigint,
+  sent_bytes bigint,
+  request_verb string,
+  request_url string,
+  request_proto string,
+  user_agent string,
+  ssl_cipher string,
+  ssl_protocol string,
+  target_group_arn string,
+  trace_id string,
+  domain_name string,
+  chosen_cert_arn string,
+  matched_rule_priority string,
+  request_creation_time string,
+  actions_executed string,
+  redirect_url string,
+  error_reason string,
+  target_port_list string,
+  target_status_code_list string,
+  classification string,
+  classification_reason string
+)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
+WITH SERDEPROPERTIES (
+  'serialization.format' = '1',
+  'input.regex' = '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\"'
+)
+LOCATION 's3://<バケット名>/AWSLogs/<AWSアカウントID>/elasticloadbalancing/ap-northeast-1/2026/05/';
+```
+
+> `<バケット名>`: `alb.tf` の `aws_s3_bucket.alb_logs` で作成されたバケット名
+> `<AWSアカウントID>`: 12桁のAWSアカウントID
+
+---
+
+## ECS - ターゲットグループのヘルスチェック確認
+
+```powershell
+$targetGroupArn = (aws ecs describe-services `
+   --cluster sandbox-aws-dev-cluster `
+   --services sandbox-aws-dev-service `
+   --query 'services[0].loadBalancers[0].targetGroupArn' `
+   --output text)
+
+aws elbv2 describe-target-health `
+   --target-group-arn $targetGroupArn `
+   --query 'TargetHealthDescriptions[*].[Target.Id,Target.Port,TargetHealth.State,TargetHealth.Description]' `
+   --output table
+```
+
+---
+
+## リソース削除
+
+```powershell
+# S3バケットを空にする (バケット名は実際のものに変更)
+aws s3 rm s3://sandbox-aws-dev-artifact-xxxxx --recursive
+aws s3 rm s3://sandbox-aws-dev-web-xxxxx --recursive
+
+# ECRリポジトリを空にする
+$repositoryName = "dev/sandbox-aws-backend"
+$imageList = aws ecr list-images --repository-name $repositoryName --query "imageIds[*]" --output json | ConvertFrom-Json
+foreach ($image in $imageList) {
+    $imageDigest = $image.imageDigest
+    $imageTag = $image.imageTag
+    $imageId = @{}
+    if ($imageDigest) { $imageId["imageDigest"] = $imageDigest }
+    if ($imageTag) { $imageId["imageTag"] = $imageTag }
+    aws ecr batch-delete-image --repository-name $repositoryName --image-ids (ConvertTo-Json @($imageId))
+}
+```
+
+---
+
+## Docker
+
+```bash
+docker build -t sandbox-backend -f ./Dockerfile .
+docker run -p 3000:3000 -e LOG_LEVEL=error sandbox-backend:latest
+```


### PR DESCRIPTION
## Summary
- `docs/operations.md` を新規作成し、コマンドを一元化
- READMEのコマンドリファレンスセクションを `docs/operations.md` へ移動し、README側はリンクのみに簡略化

## 変更内容

### docs/operations.md (新規)
- AWS認証(プロファイル切り替え・MFAトークン取得)
- CloudWatch Logs ECSログ取得
- Athena ALBアクセスログ分析用テーブル作成クエリ
- ECS ターゲットグループヘルスチェック確認
- リソース削除 / Docker

センシティブな値(アカウントID・バケット名・プロファイル名)はプレースホルダに置換済み。

### README.md
- コマンドリファレンスセクションを `docs/operations.md` へのリンク1行に簡略化
- ドキュメント一覧に `docs/operations.md` のリンクを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)