### PR TITLE
feat: index.htmlのキャッシュを無効化

### DIFF
--- a/docs/iac-spec.md
+++ b/docs/iac-spec.md
@@ -88,10 +88,13 @@ CloudFront / Front Door (CDN)
 
 **CloudFront ビヘイビア:**
 
-| パスパターン | オリジン | キャッシュ |
-|---|---|---|
-| `*` (デフォルト) | S3 | 有効 |
-| `/api/*` | ALB (VPC Origin) | 無効 |
+| 優先度 | パスパターン | オリジン | キャッシュポリシー | 備考 |
+|---|---|---|---|---|
+| デフォルト | `*` | S3 | Managed-CachingOptimized (有効) | 静的アセット |
+| 1 | `/index.html` | S3 | Managed-CachingDisabled (無効) | 再デプロイ時に常に最新を返すため |
+| 2 | `/api/*` | ALB (VPC Origin) | Managed-CachingDisabled (無効) | 全ヘッダをオリジンへ転送 |
+
+> `/index.html` は CloudFront でのキャッシュ無効化に加え、S3 アップロード時に `Cache-Control: no-store, no-cache` を付与することでブラウザキャッシュも抑止している。
 
 ### 3.4 バックエンド (ECS Fargate)
 
@@ -161,7 +164,9 @@ Source (GitHub/CodeStar)
   ▼
 Build (CodeBuild)
   │ yarn install → yarn build
-  │ S3アップロード → CloudFrontキャッシュ無効化
+  │ S3アップロード (index.html を除く全ファイル: aws s3 sync --delete --exclude "index.html")
+  │ index.html アップロード (Cache-Control: no-store, no-cache)
+  │ CloudFrontキャッシュ無効化 (/*)
 ```
 
 ### 3.9 Auth0

--- a/iac/aws/cloudfront.tf
+++ b/iac/aws/cloudfront.tf
@@ -61,6 +61,18 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
   }
 
+  # /index.html 用ビヘイビア: キャッシュ無効(SPA再デプロイ時に常に最新を返すため)
+  # priority が低い数値ほど優先されるため、/api/* より先に評価される
+  ordered_cache_behavior {
+    path_pattern           = "/index.html"
+    cache_policy_id        = data.aws_cloudfront_cache_policy.disabled.id
+    target_origin_id       = local.frontend_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+  }
+
   # /api/* 用追加ビヘイビア: キャッシュ無効・全ヘッダ転送でAPI挙動を素通し
   ordered_cache_behavior {
     path_pattern             = var.api-base-path

--- a/iac/aws/code-pipeline-frontend.tf
+++ b/iac/aws/code-pipeline-frontend.tf
@@ -153,7 +153,8 @@ resource "aws_codebuild_project" "frontend" {
                      - cat .env
                      - yarn install
                      - yarn build
-                     - aws s3 cp ./dist s3://${aws_s3_bucket.web.bucket}/ --recursive
+                     - aws s3 sync ./dist s3://${aws_s3_bucket.web.bucket}/ --delete --exclude "index.html"
+                     - aws s3 cp ./dist/index.html s3://${aws_s3_bucket.web.bucket}/index.html --cache-control "no-store, no-cache"
                      - aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.cdn.id} --paths "/*"
           EOT
     type      = "CODEPIPELINE"
@@ -303,7 +304,15 @@ resource "aws_iam_policy" "codebuild_frontend" {
           Resource = "${aws_s3_bucket.artifact.arn}/*"
         },
         {
-          Action   = "s3:PutObject"
+          Action   = "s3:ListBucket"
+          Effect   = "Allow"
+          Resource = aws_s3_bucket.web.arn
+        },
+        {
+          Action = [
+            "s3:PutObject",
+            "s3:DeleteObject",
+          ]
           Effect   = "Allow"
           Resource = "${aws_s3_bucket.web.arn}/*"
         },


### PR DESCRIPTION
## Summary

- CloudFront に `/index.html` 専用ビヘイビアを追加し `Managed-CachingDisabled` を適用（サーバーサイドキャッシュ無効化）
- CodeBuild の S3 アップロードを `sync` + `cp` に分割し、`index.html` に `Cache-Control: no-store, no-cache` を付与（ブラウザキャッシュ無効化）
- CodeBuild IAM ロールに `s3:ListBucket` / `s3:DeleteObject` を追加（`sync --delete` に必要）
- `docs/iac-spec.md` の CloudFront ビヘイビア表・パイプラインフローを更新

## Background

SPA では再デプロイ後も `index.html` がブラウザ/CloudFront にキャッシュされ、古い JS/CSS チャンクが参照され続ける問題がある。`Managed-CachingOptimized` は S3 の Cache-Control ヘッダを無視するため、CloudFront ビヘイビアとアップロード時の Cache-Control の両方で対処。

## Test plan

- [x] CodeBuild が正常完了することを確認
- [x] デプロイ後、ブラウザで `/index.html` の `Cache-Control` レスポンスヘッダが `no-store, no-cache` であることを確認
- [x] CloudFront の `/index.html` ビヘイビアが `Managed-CachingDisabled` で設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)