### PR TITLE
feat: DBコネクションプール設定を変数化

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,43 @@ terraform init && terraform apply
 
 詳細は [IaC仕様書](./docs/iac-spec.md) を参照してください。
 
+### DB接続プール設定の指針 (AWS)
+
+`iac/aws/variables.tf` の以下の変数でPrismaのコネクションプールを調整します。
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `db-connection-limit` | `5` | Prismaが1プロセスで保持するコネクション数の上限 |
+| `db-pool-timeout` | `15` | コネクション空き待ちのタイムアウト（秒） |
+
+**`db-connection-limit` の決め方:**
+
+Aurora Serverless v2 の最大コネクション数はACUに比例します。
+
+| インスタンス / ACU | メモリ | 最大コネクション数（概算） |
+|---|---|---|
+| Serverless v2 0.5 ACU | 1 GiB | 約 45 |
+| Serverless v2 1.0 ACU | 2 GiB | 約 90 |
+| Serverless v2 2.0 ACU | 4 GiB | 約 180 |
+| db.t3.medium | 4 GiB | 約 450 |
+| db.m5.large | 8 GiB | 約 900 |
+| db.m5.xlarge | 16 GiB | 約 1,800 |
+| db.m5.2xlarge | 32 GiB | 約 3,600 |
+
+> 正確な値は `LEAST({DBInstanceClassMemory / 9531392}, 5000)` で計算されます。
+
+以下の条件を満たす値を設定してください。
+
+```
+ECSタスク最大数 × db-connection-limit ≦ Aurora最大コネクション数 × 0.8 (安全マージン)
+```
+
+例: ACU最大 1.0（最大コネクション90）、ECSタスク最大10台の場合
+```
+10 × db-connection-limit ≦ 90 × 0.8 = 72
+→ db-connection-limit ≦ 7  （余裕を見て 5 程度を推奨）
+```
+
 ## ドキュメント
 
 | ドキュメント | 内容 |

--- a/docs/iac-spec.md
+++ b/docs/iac-spec.md
@@ -121,6 +121,7 @@ CloudFront / Front Door (CDN)
 | ストレージ暗号化 | 有効 |
 | アクセス | プライベートサブネットのみ |
 | 接続文字列保管 | SSM Parameter Store (SecureString) |
+| コネクションプール | `db-connection-limit` / `db-pool-timeout` 変数で指定（Prisma） |
 
 ### 3.6 ロードバランサー (ALB)
 
@@ -365,6 +366,8 @@ Front Door キャッシュパージ
 | `health-check-path` | `/health` | ヘルスチェックパス |
 | `api-expose-port` | `3000` | コンテナ公開ポート |
 | `local-pc-ip-addresses` | `[]` | 接続元IPアドレス（Bastion用） |
+| `db-connection-limit` | `5` | Prismaコネクションプール上限（設定指針は README 参照） |
+| `db-pool-timeout` | `15` | Prismaコネクション空き待ちタイムアウト（秒） |
 
 ### 6.2 AWS固有変数
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -110,6 +110,22 @@ LOCATION 's3://<バケット名>/AWSLogs/<AWSアカウントID>/elasticloadbalan
 
 ---
 
+## ECS - タスク強制再デプロイ
+
+SSMパラメータストアの値を変更した場合（DATABASE_URL等）、実行中のタスクには自動反映されません。
+以下のコマンドで新しいタスクを起動し、最新のパラメータ値を反映させてください。
+
+```powershell
+aws ecs update-service `
+  --cluster sandbox-aws-dev-cluster `
+  --service sandbox-aws-dev-service `
+  --force-new-deployment
+```
+
+> SSMパラメータの値はタスク起動時にのみ取得されるため、`terraform apply` 後は必ずタスクの再デプロイが必要です。
+
+---
+
 ## ECS - ターゲットグループのヘルスチェック確認
 
 ```powershell

--- a/iac/aws/aurora_serverless_v2.tf
+++ b/iac/aws/aurora_serverless_v2.tf
@@ -15,6 +15,7 @@ resource "random_string" "db_password" {
 }
 
 # DB接続文字列(DATABASE_URL)を組み立て: SSMパラメータに保存しECSタスクへ注入する
+# connection_limit / pool_timeout は variables.tf で管理 (設定指針は README.md 参照)
 locals {
   db_raw_password     = random_string.db_password.result
   db_encoded_password = urlencode(local.db_raw_password)
@@ -31,7 +32,9 @@ locals {
       "/",
       "${aws_rds_cluster.cluster.database_name}",
       "?",
-      "sslmode=require"
+      "sslmode=require",
+      "&connection_limit=${var.db-connection-limit}",
+      "&pool_timeout=${var.db-pool-timeout}"
     ]
   )
 }
@@ -77,5 +80,5 @@ resource "aws_ssm_parameter" "db_connection_string" {
   tier             = "Standard"
   type             = "SecureString"
   value_wo         = local.database_url
-  value_wo_version = 1
+  value_wo_version = 2
 }

--- a/iac/aws/variables.tf
+++ b/iac/aws/variables.tf
@@ -93,3 +93,24 @@ variable "local-pc-ip-addresses" {
   default     = []
   description = "接続元のIPアドレス"
 }
+
+# Prismaコネクションプール設定
+# 設定指針: ECSタスク最大数 × db-connection-limit ≦ Aurora最大コネクション数 × 0.8 (安全マージン)
+# Aurora最大コネクション数の目安 (DBInstanceClassMemory / 9,531,392):
+#   Serverless v2 1ACU    → 約   90
+#   db.t3.medium  (4GiB)  → 約  450
+#   db.m5.large   (8GiB)  → 約  900
+#   db.m5.xlarge  (16GiB) → 約 1800
+#   db.m5.2xlarge (32GiB) → 約 3600
+variable "db-connection-limit" {
+  type        = number
+  default     = 5
+  description = "Prismaが1プロセスで保持するコネクション数の上限。ECSタスク数との積がAuroraの最大コネクション数を超えないよう設定する"
+}
+
+# Prismaがコネクションプールの空きを待つタイムアウト(秒)
+variable "db-pool-timeout" {
+  type        = number
+  default     = 15
+  description = "Prismaのコネクションプール空き待ちタイムアウト(秒)"
+}


### PR DESCRIPTION
## Summary

- `db-connection-limit` / `db-pool-timeout` を `variables.tf` に追加し、`DATABASE_URL` のハードコード値を変数参照に変更
- `value_wo_version` を `2` に更新し `terraform apply` で SSM パラメータが反映されるよう変更
- `README.md` にインスタンス種別ごとの最大コネクション数（Serverless v2〜db.m5.2xlarge）と設定指針を追記
- `docs/operations.md` に SSM パラメータ変更後の ECS タスク強制再デプロイ手順を追記

## Background

Aurora PostgreSQL の最大コネクション数はインスタンスメモリに依存する（`DBInstanceClassMemory / 9,531,392`）。Prisma のデフォルトプール数では ECS タスクが増えた際にコネクション枯渇するリスクがあるため、明示的に変数で管理する。

## Test plan

- [x] `terraform plan` で SSM パラメータに change が出ることを確認
- [x] `terraform apply` 後、ECS タスクを強制再デプロイし新しい `DATABASE_URL` が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)