### PR TITLE
feat: ECR・CloudWatch Logs・S3のVPCエンドポイントを追加

### DIFF
--- a/docs/iac-spec.md
+++ b/docs/iac-spec.md
@@ -75,7 +75,19 @@ CloudFront / Front Door (CDN)
 | プライベートサブネット 1 | `172.16.2.0/24` | ap-northeast-1a |
 | プライベートサブネット 2 | `172.16.3.0/24` | ap-northeast-1c |
 
-**VPCエンドポイント:** AWSサービスへのプライベートアクセス用
+**VPCエンドポイント:** NAT Gatewayを経由せずAWSサービスへプライベートアクセスするため
+
+| エンドポイント | タイプ | 用途 |
+|---|---|---|
+| `ssm` | Interface | Session Manager (Bastion) |
+| `ssmmessages` | Interface | Session Manager メッセージ通信 |
+| `ec2messages` | Interface | EC2メッセージ通信 |
+| `ecr.api` | Interface | ECS FargateのECR APIアクセス |
+| `ecr.dkr` | Interface | ECS FargateのDockerイメージPull |
+| `logs` | Interface | ECSコンテナログのCloudWatch Logs送信 |
+| `s3` | Gateway（無料） | ECRイメージレイヤー(S3格納)取得 |
+
+> Auth0 JWKSエンドポイント等の外部サービス呼び出しはVPCエンドポイントで代替できないため、NAT Gatewayは引き続き必要。
 
 ### 3.3 フロントエンド (S3 + CloudFront)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -126,6 +126,29 @@ aws ecs update-service `
 
 ---
 
+## ECS - ECS Execの有効・無効切り替え
+
+ECS Execは `ecs.tf` の `enable_execute_command = true` で有効化されています。
+コンテナへのシェル接続が可能になるため、調査・デバッグが不要な場合は無効化してください。
+
+```powershell
+# 無効化
+aws ecs update-service `
+  --cluster sandbox-aws-dev-cluster `
+  --service sandbox-aws-dev-service `
+  --enable-execute-command false
+
+# 有効化
+aws ecs update-service `
+  --cluster sandbox-aws-dev-cluster `
+  --service sandbox-aws-dev-service `
+  --enable-execute-command true
+```
+
+> CLIでの変更は一時的な対処です。恒久的に変更する場合は `ecs.tf` の `enable_execute_command` を変更して `terraform apply` してください。
+
+---
+
 ## ECS - VPCエンドポイント経由の通信確認
 
 VPCエンドポイント（Interface）が有効な場合、エンドポイントのDNS名がVPC内のプライベートIPに解決されます。

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -126,6 +126,44 @@ aws ecs update-service `
 
 ---
 
+## ECS - VPCエンドポイント経由の通信確認
+
+VPCエンドポイント（Interface）が有効な場合、エンドポイントのDNS名がVPC内のプライベートIPに解決されます。
+ECS Execでコンテナに接続し、DNS解決結果のIPアドレスで判定します。
+
+```powershell
+# ECS Execでコンテナに接続
+$taskArn = (aws ecs list-tasks `
+  --cluster sandbox-aws-dev-cluster `
+  --service-name sandbox-aws-dev-service `
+  --query 'taskArns[0]' `
+  --output text)
+
+aws ecs execute-command `
+  --cluster sandbox-aws-dev-cluster `
+  --task $taskArn `
+  --container sandbox-aws `
+  --command "/bin/sh" `
+  --interactive
+```
+
+コンテナ内で実行:
+
+```sh
+# ECR APIエンドポイントのDNS解決
+node -e "require('dns').lookup('api.ecr.ap-northeast-1.amazonaws.com', (err, addr) => console.log(addr))"
+
+# CloudWatch LogsエンドポイントのDNS解決
+node -e "require('dns').lookup('logs.ap-northeast-1.amazonaws.com', (err, addr) => console.log(addr))"
+```
+
+| 返ってくるIP | 意味 |
+|---|---|
+| VPC CIDRの範囲内（例: `172.16.x.x`） | VPCエンドポイント経由 ✅ |
+| パブリックIP | NAT Gateway経由 ❌ |
+
+---
+
 ## ECS - ターゲットグループのヘルスチェック確認
 
 ```powershell

--- a/iac/aws/ecs.tf
+++ b/iac/aws/ecs.tf
@@ -233,7 +233,7 @@ resource "aws_ecs_service" "service" {
   deployment_minimum_healthy_percent = 100
   desired_count                      = 1
   enable_ecs_managed_tags            = true
-  enable_execute_command             = true
+  enable_execute_command             = true  # ECS Execを有効化(調査・デバッグ用)。不要な場合はfalseに変更してapplyすること
   health_check_grace_period_seconds  = 0
   launch_type                        = "FARGATE"
   name                               = "${var.app-name}-${var.environment}-service"

--- a/iac/aws/vpc_endpoint.tf
+++ b/iac/aws/vpc_endpoint.tf
@@ -18,7 +18,7 @@ resource "aws_vpc_endpoint" "ssm" {
   security_group_ids = [
     aws_security_group.ssm.id,
   ]
-  service_name = "com.amazonaws.ap-northeast-1.ssm"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.ssm"
   subnet_ids = [
     aws_subnet.private1c.id,
   ]
@@ -52,7 +52,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   security_group_ids = [
     aws_security_group.ssm.id,
   ]
-  service_name = "com.amazonaws.ap-northeast-1.ssmmessages"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   subnet_ids = [
     aws_subnet.private1c.id,
   ]
@@ -86,7 +86,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
   security_group_ids = [
     aws_security_group.ssm.id,
   ]
-  service_name = "com.amazonaws.ap-northeast-1.ec2messages"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.ec2messages"
   subnet_ids = [
     aws_subnet.private1c.id,
   ]
@@ -99,4 +99,85 @@ resource "aws_vpc_endpoint" "ec2messages" {
     dns_record_ip_type = "ipv4"
   }
   timeouts {}
+}
+
+# ECR API用VPCエンドポイント: ECS FargateがECRのコントロールプレーンAPIへNATを経由せずアクセスするため
+resource "aws_vpc_endpoint" "ecr_api" {
+  ip_address_type     = "ipv4"
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.ssm.id,
+  ]
+  service_name = "com.amazonaws.${data.aws_region.current.region}.ecr.api"
+  subnet_ids = [
+    aws_subnet.private1a.id,
+    aws_subnet.private1c.id,
+  ]
+  tags = {
+    "Name" = "${var.environment}-ecr-api",
+  }
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.vpc.id
+  dns_options {
+    dns_record_ip_type = "ipv4"
+  }
+}
+
+# ECR DKR用VPCエンドポイント: ECS FargateがDockerイメージレイヤーをNATを経由せずPullするため
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  ip_address_type     = "ipv4"
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.ssm.id,
+  ]
+  service_name = "com.amazonaws.${data.aws_region.current.region}.ecr.dkr"
+  subnet_ids = [
+    aws_subnet.private1a.id,
+    aws_subnet.private1c.id,
+  ]
+  tags = {
+    "Name" = "${var.environment}-ecr-dkr",
+  }
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.vpc.id
+  dns_options {
+    dns_record_ip_type = "ipv4"
+  }
+}
+
+# CloudWatch Logs用VPCエンドポイント: ECSコンテナログをNATを経由せずCloudWatch Logsへ送信するため
+resource "aws_vpc_endpoint" "logs" {
+  ip_address_type     = "ipv4"
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.ssm.id,
+  ]
+  service_name = "com.amazonaws.${data.aws_region.current.region}.logs"
+  subnet_ids = [
+    aws_subnet.private1a.id,
+    aws_subnet.private1c.id,
+  ]
+  tags = {
+    "Name" = "${var.environment}-logs",
+  }
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.vpc.id
+  dns_options {
+    dns_record_ip_type = "ipv4"
+  }
+}
+
+# S3用VPCゲートウェイエンドポイント: ECRイメージレイヤー(S3格納)取得をNATを経由せず行うため
+# GatewayタイプはSGではなくルートテーブルへの関連付けで制御し、追加費用なし
+resource "aws_vpc_endpoint" "s3" {
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  vpc_id            = aws_vpc.vpc.id
+  route_table_ids = [
+    aws_route_table.main.id,
+    aws_route_table.custom.id,
+  ]
+  tags = {
+    "Name" = "${var.environment}-s3",
+  }
 }


### PR DESCRIPTION
## Summary

- `ecr.api` / `ecr.dkr` (Interface): ECS FargateのECRイメージPullをNAT経由から切り替え
- `logs` (Interface): ECSコンテナログのCloudWatch Logs送信をNAT経由から切り替え
- `s3` (Gateway・無料): ECRイメージレイヤー（S3格納）取得をNAT経由から切り替え
- 既存エンドポイントを含む全 `service_name` のリージョンを `data.aws_region.current.region` で変数化
- `docs/iac-spec.md` にVPCエンドポイント一覧表を追記
- `docs/operations.md` にVPCエンドポイント経由確認手順（Node.jsによるDNS解決確認）を追記

## Background

NAT Gatewayを経由するECR/CloudWatch Logs/S3トラフィックをVPCエンドポイント経由に切り替えることでデータ転送コストを削減する。Auth0 JWKSエンドポイント等の外部呼び出しはVPCエンドポイントで代替できないため、NAT Gatewayは引き続き維持。

## Test plan

- [x] `terraform apply` でエンドポイントが作成されることを確認
- [x] ECS Execでコンテナに接続し、DNS解決でVPC CIDRのIPが返ることを確認
  ```sh
  node -e "require('dns').lookup('api.ecr.ap-northeast-1.amazonaws.com', (err, addr) => console.log(addr))"
  node -e "require('dns').lookup('logs.ap-northeast-1.amazonaws.com', (err, addr) => console.log(addr))"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)