### PR TITLE
docs: VPC CIDRを変数参照に統一し設計指針を追記

### DIFF
--- a/docs/iac-spec.md
+++ b/docs/iac-spec.md
@@ -68,12 +68,19 @@ CloudFront / Front Door (CDN)
 
 **VPC構成:**
 
-| リソース | CIDR / 設定 | AZ |
-|---|---|---|
-| VPC | `172.16.0.0/16` | - |
-| パブリックサブネット | `172.16.1.0/24` | ap-northeast-1a |
-| プライベートサブネット 1 | `172.16.2.0/24` | ap-northeast-1a |
-| プライベートサブネット 2 | `172.16.3.0/24` | ap-northeast-1c |
+| リソース | 変数名 | デフォルト値 | AZ |
+|---|---|---|---|
+| VPC | `vpc_cidr_block` | `172.16.0.0/16` | - |
+| パブリックサブネット | `subnet_public1a_cidr_block` | `172.16.1.0/24` | ap-northeast-1a |
+| プライベートサブネット 1 | `subnet_private1a_cidr_block` | `172.16.2.0/24` | ap-northeast-1a |
+| プライベートサブネット 2 | `subnet_private1c_cidr_block` | `172.16.3.0/24` | ap-northeast-1c |
+
+> **⚠️ CIDRアドレスの設計について**
+> デフォルト値はそのまま使用できますが、以下のケースでは変更が必要です。
+> - 既存VPCやオンプレミスネットワークとVPCピアリング / VPN接続する場合（CIDRの重複不可）
+> - 社内ネットワークのアドレス体系に合わせる必要がある場合
+>
+> 変更する場合は `terraform.tfvars` で上書きしてください。サブネットはVPC CIDRの範囲内に収めること。
 
 **VPCエンドポイント:** NAT Gatewayを経由せずAWSサービスへプライベートアクセスするため
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -182,7 +182,7 @@ node -e "require('dns').lookup('logs.ap-northeast-1.amazonaws.com', (err, addr) 
 
 | 返ってくるIP | 意味 |
 |---|---|
-| VPC CIDRの範囲内（例: `172.16.x.x`） | VPCエンドポイント経由 ✅ |
+| VPC CIDRの範囲内（`vpc_cidr_block` 変数で設定した範囲） | VPCエンドポイント経由 ✅ |
 | パブリックIP | NAT Gateway経由 ❌ |
 
 ---


### PR DESCRIPTION
## Summary

- `docs/iac-spec.md` のVPC構成表にCIDR変数名（`vpc_cidr_block` 等）を明記
- VPCピアリング・VPN接続時のCIDR重複回避が必要な旨の設計注意事項を追記
- `docs/operations.md` のVPCエンドポイント確認手順でハードコードしていた `172.16.x.x` を `vpc_cidr_block` 変数の参照に変更

## Background

デフォルトCIDR（`172.16.0.0/16`）がドキュメントにハードコードされており、環境ごとに変更が必要なケースで混乱が生じる可能性があるため、変数名を明示して設計指針を追記する。

## Test plan

- [x] ドキュメントの内容が実際の `variables.tf` の変数名と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)