### PR TITLE
feat: ALBアクセスログをAthenaでpartition projectionを使って自動分析できるよう追加

### DIFF
--- a/iac/aws/alb.tf
+++ b/iac/aws/alb.tf
@@ -126,10 +126,4 @@ resource "aws_athena_workgroup" "alb_logs" {
   }
 }
 
-# AthenaデータベースDB
-resource "aws_athena_database" "alb_logs" {
-  name   = "${replace(var.app-name, "-", "_")}_${var.environment}_alb_logs"
-  bucket = aws_s3_bucket.athena_results.bucket
-}
-
 

--- a/iac/aws/athena_alb_logs.tf
+++ b/iac/aws/athena_alb_logs.tf
@@ -1,0 +1,180 @@
+# Glueデータベース: ALBアクセスログ分析用データカタログ
+# aws_athena_database の代わりに Glue カタログで管理し partition projection を利用可能にする
+resource "aws_glue_catalog_database" "alb_logs" {
+  name = "${replace(var.app-name, "-", "_")}_${var.environment}_alb_logs"
+}
+
+# ALBアクセスログ用Glueテーブル
+# - RegexSerDe で空白・クォートを含むフィールド(request, user_agent)を正しく分割
+# - partition projectionで day パーティションを動的解決(MSCK REPAIR / 手動addPartition不要)
+# - フィールド定義はAWS公式DDLに準拠(33フィールド)
+resource "aws_glue_catalog_table" "alb_logs" {
+  name          = "alb_access_logs"
+  database_name = aws_glue_catalog_database.alb_logs.name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    "EXTERNAL"                     = "TRUE"
+    "projection.enabled"           = "true"
+    "projection.day.type"          = "date"
+    "projection.day.range"         = "NOW-1YEARS,NOW"
+    "projection.day.format"        = "yyyy/MM/dd"
+    "projection.day.interval"      = "1"
+    "projection.day.interval.unit" = "DAYS"
+    "storage.location.template"    = "s3://${aws_s3_bucket.alb_logs.bucket}/AWSLogs/${data.aws_caller_identity.self.account_id}/elasticloadbalancing/${data.aws_region.current.region}/$${day}/"
+  }
+
+  partition_keys {
+    name = "day"
+    type = "string"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.alb_logs.bucket}/AWSLogs/${data.aws_caller_identity.self.account_id}/elasticloadbalancing/${data.aws_region.current.region}/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    # RegexSerDe: requestフィールド(メソッド URL プロトコル)やuser_agentに空白が含まれるため
+    # LazySimpleSerDeの空白区切りでは分割できず、正規表現で各フィールドを抽出する
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.RegexSerDe"
+      parameters = {
+        "input.regex" = "([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\\s]+?)\" \"([^\\s]+)\" \"([^ ]*)\" \"([^ ]*)\""
+      }
+    }
+
+    # フィールド順序・型はAWS公式ALBアクセスログDDLに準拠
+    columns {
+      name = "type"
+      type = "string"
+    }
+    columns {
+      name = "time"
+      type = "string"
+    }
+    columns {
+      name = "elb"
+      type = "string"
+    }
+    columns {
+      name = "client_ip"
+      type = "string"
+    }
+    columns {
+      name = "client_port"
+      type = "int"
+    }
+    columns {
+      name = "target_ip"
+      type = "string"
+    }
+    columns {
+      name = "target_port"
+      type = "int"
+    }
+    columns {
+      name = "request_processing_time"
+      type = "double"
+    }
+    columns {
+      name = "target_processing_time"
+      type = "double"
+    }
+    columns {
+      name = "response_processing_time"
+      type = "double"
+    }
+    columns {
+      name = "elb_status_code"
+      type = "string"
+    }
+    columns {
+      name = "target_status_code"
+      type = "string"
+    }
+    columns {
+      name = "received_bytes"
+      type = "bigint"
+    }
+    columns {
+      name = "sent_bytes"
+      type = "bigint"
+    }
+    columns {
+      name = "request_verb"
+      type = "string"
+    }
+    columns {
+      name = "request_url"
+      type = "string"
+    }
+    columns {
+      name = "request_proto"
+      type = "string"
+    }
+    columns {
+      name = "user_agent"
+      type = "string"
+    }
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+    columns {
+      name = "target_group_arn"
+      type = "string"
+    }
+    columns {
+      name = "trace_id"
+      type = "string"
+    }
+    columns {
+      name = "domain_name"
+      type = "string"
+    }
+    columns {
+      name = "chosen_cert_arn"
+      type = "string"
+    }
+    columns {
+      name = "matched_rule_priority"
+      type = "string"
+    }
+    columns {
+      name = "request_creation_time"
+      type = "string"
+    }
+    columns {
+      name = "actions_executed"
+      type = "string"
+    }
+    columns {
+      name = "redirect_url"
+      type = "string"
+    }
+    columns {
+      name = "error_reason"
+      type = "string"
+    }
+    columns {
+      name = "target_port_list"
+      type = "string"
+    }
+    columns {
+      name = "target_status_code_list"
+      type = "string"
+    }
+    columns {
+      name = "classification"
+      type = "string"
+    }
+    columns {
+      name = "classification_reason"
+      type = "string"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `alb.tf` の `aws_athena_database` を削除し、Glueカタログ管理に移行（partition projectionを使うために必要）
- `athena_alb_logs.tf` を新規追加：Glue DB + テーブル（partition projection付き）
- partition projectionにより、新しい日付パーティションが増えても `MSCK REPAIR` 不要で自動的にクエリ可能

## 変更ファイル

- `iac/aws/alb.tf` — `aws_athena_database.alb_logs` を削除
- `iac/aws/athena_alb_logs.tf` — Glue DB / テーブル（RegexSerDe + partition projection、33フィールド）

## 備考

ALBアクセスログは `request`・`user_agent` フィールドに空白が含まれるため、VPCフローログ（空白区切り）と異なり RegexSerDe で各フィールドを抽出しています。フィールド定義はAWS公式DDLに準拠しています。

## Test plan

- [ ] `terraform plan` で `aws_athena_database` の削除と Glue DB/Table の追加が見えることを確認
- [ ] `terraform apply` 完了
- [ ] Athena コンソールでワークグループを `{app-name}-{environment}-alb-logs` に切替え、`alb_access_logs` テーブルへのクエリが正常に返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)