### PR TITLE
docs: READMEにS3ストレージ階層化ポリシーの説明を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,15 @@ GROUP BY request_url
 ORDER BY avg_sec DESC LIMIT 10;
 ```
 
-> クエリ結果は7日後に自動削除されます（`alb.tf` の `athena_results` バケットライフサイクル設定）。
+**S3保管ポリシー（VPCフローログ・ALBアクセスログ共通）**
+
+| 期間 | ストレージクラス | Athenaクエリ |
+|---|---|---|
+| 0〜30日 | Standard | 可 |
+| 31〜365日 | Standard-IA | 可（コスト約60%減） |
+| 365日以降 | Glacier | 不可（保管のみ） |
+
+> Athenaクエリ結果は7日後に自動削除されます（`alb.tf` の `athena_results` バケットライフサイクル設定）。
 
 ## ドキュメント
 


### PR DESCRIPTION
## Summary

ログ分析セクションにS3保管ポリシー（Standard → Standard-IA → Glacier）の表を追加。PR #35・#36 の変更に対応したドキュメント更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)