### PR TITLE
feat: FireLensでECSログをCloudWatch Logs+S3に二重出力（ヘルスチェック除外）

### DIFF
--- a/backend/sandbox-backend/Dockerfile
+++ b/backend/sandbox-backend/Dockerfile
@@ -1,5 +1,5 @@
 ########## Build Stage ##########
-FROM node:22-bookworm-slim AS builder
+FROM public.ecr.aws/docker/library/node:22-bookworm-slim AS builder
 
 WORKDIR /usr/src/app
 
@@ -31,7 +31,7 @@ RUN yarn build
 
 
 ########## Runtime Stage ##########
-FROM node:22-bookworm-slim
+FROM public.ecr.aws/docker/library/node:22-bookworm-slim
 
 # OpenSSL と CA を追加（サイズ削減のため後片付け）
 RUN apt-get update -y \

--- a/iac/aws/ecs.tf
+++ b/iac/aws/ecs.tf
@@ -34,7 +34,7 @@ resource "aws_ecs_cluster" "cluster" {
   tags = {}
 }
 
-# CloudWatch Logsロググループ: ECSコンテナの標準出力を集約(保持7日)
+# CloudWatch Logsロググループ: FireLens(Fluent Bit)経由でアプリログを集約(保持7日)
 resource "aws_cloudwatch_log_group" "backend" {
   name              = "/ecs/${var.app-name}-${var.environment}-log"
   retention_in_days = 7
@@ -47,27 +47,28 @@ resource "aws_ecs_task_definition" "task_definition" {
   container_definitions = jsonencode(
     [
       {
-        cpu         = 0
-        environment = []
-        essential   = true
-        image       = "${aws_ecr_repository.backend.repository_url}:latest"
-        logConfiguration = {
-          logDriver = "awslogs"
-          options = {
-            awslogs-group         = aws_cloudwatch_log_group.backend.name
-            awslogs-region        = data.aws_region.current.region
-            awslogs-stream-prefix = "ecs"
+        cpu       = 0
+        essential = true
+        image     = "${aws_ecr_repository.backend.repository_url}:latest"
+        name      = "${var.app-name}"
+        dependsOn = [
+          {
+            containerName = "log_router"
+            condition     = "START"
           }
+        ]
+        logConfiguration = {
+          logDriver = "awsfirelens"
+          options   = {}
         }
         mountPoints = []
-        name        = "${var.app-name}"
         portMappings = [
           {
             containerPort = var.api-expose-port
             hostPort      = var.api-expose-port
             protocol      = "tcp"
           },
-        ],
+        ]
         environment = [
           {
             "name"  = "PORT",
@@ -81,17 +82,14 @@ resource "aws_ecs_task_definition" "task_definition" {
             "name"  = "AUTH0_DOMAIN",
             "value" = var.auth0_domain
           },
-
           {
             "name"  = "AUTH0_AUDIENCE",
             "value" = "https://${aws_cloudfront_distribution.cdn.domain_name}"
           },
-
           {
             "name"  = "CORS_ORIGIN",
             "value" = "https://${aws_cloudfront_distribution.cdn.domain_name}"
           },
-
           {
             "name"  = "CORS_METHODS",
             "value" = "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS"
@@ -104,7 +102,7 @@ resource "aws_ecs_task_definition" "task_definition" {
             "name"  = "PRISMA_LOG_LEVEL",
             "value" = "query,info,warn,error"
           }
-        ],
+        ]
         secrets = [
           {
             name      = "DATABASE_URL"
@@ -112,6 +110,31 @@ resource "aws_ecs_task_definition" "task_definition" {
           }
         ]
         volumesFrom = []
+      },
+      {
+        name      = "log_router"
+        image     = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+        essential = true
+        cpu       = 0
+        mountPoints  = []
+        portMappings = []
+        environment  = []
+        volumesFrom  = []
+        firelensConfiguration = {
+          type = "fluentbit"
+          options = {
+            "config-file-type"  = "s3"
+            "config-file-value" = "arn:aws:s3:::${aws_s3_bucket.fluent_bit_config.bucket}/fluent-bit.conf"
+          }
+        }
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.firelens.name
+            awslogs-region        = data.aws_region.current.region
+            awslogs-stream-prefix = "firelens"
+          }
+        }
       },
     ]
   )

--- a/iac/aws/ecs.tf
+++ b/iac/aws/ecs.tf
@@ -113,18 +113,35 @@ resource "aws_ecs_task_definition" "task_definition" {
       },
       {
         name      = "log_router"
-        image     = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+        image     = "${aws_ecr_repository.fluent_bit.repository_url}:latest"
         essential = true
         cpu       = 0
         mountPoints  = []
         portMappings = []
-        environment  = []
         volumesFrom  = []
+        environment = [
+          {
+            name  = "HEALTH_CHECK_PATH"
+            value = var.health-check-path
+          },
+          {
+            name  = "AWS_REGION"
+            value = data.aws_region.current.region
+          },
+          {
+            name  = "CW_LOG_GROUP"
+            value = aws_cloudwatch_log_group.backend.name
+          },
+          {
+            name  = "ECS_LOG_BUCKET"
+            value = aws_s3_bucket.ecs_logs.bucket
+          },
+        ]
         firelensConfiguration = {
           type = "fluentbit"
           options = {
-            "config-file-type"  = "s3"
-            "config-file-value" = "arn:aws:s3:::${aws_s3_bucket.fluent_bit_config.bucket}/fluent-bit.conf"
+            "config-file-type"  = "file"
+            "config-file-value" = "/fluent-bit/etc/extra.conf"
           }
         }
         logConfiguration = {

--- a/iac/aws/ecs_logs.tf
+++ b/iac/aws/ecs_logs.tf
@@ -31,49 +31,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "ecs_logs" {
   }
 }
 
-# Fluent Bit設定ファイル用S3バケット
-resource "aws_s3_bucket" "fluent_bit_config" {
-  bucket        = "${var.app-name}-${var.environment}-fluent-bit-config-${random_string.suffix.result}"
-  force_destroy = true
-  tags          = {}
-}
-
-resource "aws_s3_bucket_public_access_block" "fluent_bit_config" {
-  bucket                  = aws_s3_bucket.fluent_bit_config.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-# Fluent Bit設定: ヘルスチェック除外 → CloudWatch Logs(7日) + S3 に二重出力
-resource "aws_s3_object" "fluent_bit_config" {
-  bucket = aws_s3_bucket.fluent_bit_config.id
-  key    = "fluent-bit.conf"
-  content = <<-EOT
-[FILTER]
-    Name    grep
-    Match   *
-    Exclude log ${var.health-check-path}
-
-[OUTPUT]
-    Name              cloudwatch_logs
-    Match             *
-    region            ${data.aws_region.current.region}
-    log_group_name    ${aws_cloudwatch_log_group.backend.name}
-    log_stream_prefix ecs/
-    auto_create_group false
-
-[OUTPUT]
-    Name              s3
-    Match             *
-    region            ${data.aws_region.current.region}
-    bucket            ${aws_s3_bucket.ecs_logs.bucket}
-    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S
-    compression       gzip
-    total_file_size   50M
-    upload_timeout    10m
-EOT
+# カスタムFluentBitイメージ用ECRリポジトリ
+# ヘルスチェック除外フィルタとCloudWatch Logs + S3 二重出力設定を焼き込んだイメージを格納する
+resource "aws_ecr_repository" "fluent_bit" {
+  name                 = "${var.environment}/fluent-bit"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+  tags                 = {}
 }
 
 # FireLensコンテナ(log_router)自身のログ用ロググループ
@@ -101,28 +65,6 @@ resource "aws_iam_role_policy" "ecs_task_firelens" {
         Effect   = "Allow"
         Action   = "s3:PutObject"
         Resource = "${aws_s3_bucket.ecs_logs.arn}/*"
-      }
-    ]
-  })
-}
-
-# タスク実行ロール: ECSエージェントがFluentBit設定ファイルをS3から取得する権限
-resource "aws_iam_role_policy" "execute_ecs_task_fluent_bit" {
-  name = "fluent-bit-config"
-  role = aws_iam_role.execute_ecs_task.name
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:GetBucketLocation"
-        ]
-        Resource = [
-          "${aws_s3_bucket.fluent_bit_config.arn}",
-          "${aws_s3_bucket.fluent_bit_config.arn}/*"
-        ]
       }
     ]
   })

--- a/iac/aws/ecs_logs.tf
+++ b/iac/aws/ecs_logs.tf
@@ -1,0 +1,129 @@
+# ECSアプリケーションログ用S3バケット (Fluent Bit/FireLens経由で書き込む)
+resource "aws_s3_bucket" "ecs_logs" {
+  bucket        = "${var.app-name}-${var.environment}-ecs-logs-${random_string.suffix.result}"
+  force_destroy = true
+  tags          = {}
+}
+
+resource "aws_s3_bucket_public_access_block" "ecs_logs" {
+  bucket                  = aws_s3_bucket.ecs_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Standard → Standard-IA(31日) → Glacier(365日) で長期保存
+resource "aws_s3_bucket_lifecycle_configuration" "ecs_logs" {
+  bucket = aws_s3_bucket.ecs_logs.id
+  rule {
+    id     = "tiering"
+    status = "Enabled"
+    filter {}
+    transition {
+      days          = 31
+      storage_class = "STANDARD_IA"
+    }
+    transition {
+      days          = 365
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+# Fluent Bit設定ファイル用S3バケット
+resource "aws_s3_bucket" "fluent_bit_config" {
+  bucket        = "${var.app-name}-${var.environment}-fluent-bit-config-${random_string.suffix.result}"
+  force_destroy = true
+  tags          = {}
+}
+
+resource "aws_s3_bucket_public_access_block" "fluent_bit_config" {
+  bucket                  = aws_s3_bucket.fluent_bit_config.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Fluent Bit設定: ヘルスチェック除外 → CloudWatch Logs(7日) + S3 に二重出力
+resource "aws_s3_object" "fluent_bit_config" {
+  bucket = aws_s3_bucket.fluent_bit_config.id
+  key    = "fluent-bit.conf"
+  content = <<-EOT
+[FILTER]
+    Name    grep
+    Match   *
+    Exclude log ${var.health-check-path}
+
+[OUTPUT]
+    Name              cloudwatch_logs
+    Match             *
+    region            ${data.aws_region.current.region}
+    log_group_name    ${aws_cloudwatch_log_group.backend.name}
+    log_stream_prefix ecs/
+    auto_create_group false
+
+[OUTPUT]
+    Name              s3
+    Match             *
+    region            ${data.aws_region.current.region}
+    bucket            ${aws_s3_bucket.ecs_logs.bucket}
+    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S
+    compression       gzip
+    total_file_size   50M
+    upload_timeout    10m
+EOT
+}
+
+# FireLensコンテナ(log_router)自身のログ用ロググループ
+resource "aws_cloudwatch_log_group" "firelens" {
+  name              = "/ecs/firelens/${var.app-name}-${var.environment}"
+  retention_in_days = 7
+}
+
+# タスクロール: Fluent BitがCloudWatch Logsへ書き込む + S3へ書き込む権限
+resource "aws_iam_role_policy" "ecs_task_firelens" {
+  name = "firelens-output"
+  role = aws_iam_role.ecs_task.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "${aws_cloudwatch_log_group.backend.arn}:*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.ecs_logs.arn}/*"
+      }
+    ]
+  })
+}
+
+# タスク実行ロール: ECSエージェントがFluentBit設定ファイルをS3から取得する権限
+resource "aws_iam_role_policy" "execute_ecs_task_fluent_bit" {
+  name = "fluent-bit-config"
+  role = aws_iam_role.execute_ecs_task.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          "${aws_s3_bucket.fluent_bit_config.arn}",
+          "${aws_s3_bucket.fluent_bit_config.arn}/*"
+        ]
+      }
+    ]
+  })
+}

--- a/iac/aws/fluent-bit/Dockerfile
+++ b/iac/aws/fluent-bit/Dockerfile
@@ -1,0 +1,2 @@
+FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
+COPY extra.conf /fluent-bit/etc/extra.conf

--- a/iac/aws/fluent-bit/extra.conf
+++ b/iac/aws/fluent-bit/extra.conf
@@ -1,0 +1,22 @@
+[FILTER]
+    Name    grep
+    Match   *
+    Exclude log ${HEALTH_CHECK_PATH}
+
+[OUTPUT]
+    Name              cloudwatch_logs
+    Match             *
+    region            ${AWS_REGION}
+    log_group_name    ${CW_LOG_GROUP}
+    log_stream_prefix ecs/
+    auto_create_group false
+
+[OUTPUT]
+    Name              s3
+    Match             *
+    region            ${AWS_REGION}
+    bucket            ${ECS_LOG_BUCKET}
+    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S
+    compression       gzip
+    total_file_size   50M
+    upload_timeout    10m


### PR DESCRIPTION
## Summary

- FireLens（Fluent Bit）サイドカーをECSタスクに追加し、ログをCloudWatch Logs（7日保持）とS3（長期保存）に同時出力
- `/health` へのヘルスチェックログを両出力先から除外
- カスタムFluentBitイメージ（`iac/aws/fluent-bit/`）をECRに格納する方式を採用（FargateはS3設定ファイル非対応のため）
- ECSログ用S3バケットを追加（31日→Standard-IA、365日→Glacier）
- バックエンドDockerfileのベースイメージをECR Publicミラーに変更（Docker Hubレートリミット回避）

## 変更ファイル

- `iac/aws/ecs.tf` - ログドライバーをawslogs→awsfirelensに変更、log_routerサイドカー追加
- `iac/aws/ecs_logs.tf` - S3バケット、ECRリポジトリ、IAMポリシー追加
- `iac/aws/fluent-bit/Dockerfile` - カスタムFluentBitイメージ定義
- `iac/aws/fluent-bit/extra.conf` - フィルタ・出力先設定
- `backend/sandbox-backend/Dockerfile` - ベースイメージをECR Publicミラーに変更

## 初回デプロイ手順

1. `terraform apply` でECRリポジトリ作成
2. `iac/aws/fluent-bit/` でカスタムイメージをビルド＆ECRにプッシュ
3. CodePipelineを実行してECSサービスを更新

## Test plan

- [ ] CodePipelineが正常完了すること
- [ ] ECSタスクにlog_routerコンテナが含まれること
- [ ] CloudWatch Logsにアプリログが出力されること（/healthは除外）
- [ ] S3バケット（ecs-logs）にログファイルが書き込まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)