### PR TITLE
feat: FireLensでECSログをCloudWatch Logs+S3に二重出力（ヘルスチェック・ANSIカラー除外）

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,31 @@ ORDER BY avg_sec DESC LIMIT 10;
 
 > クエリ結果は7日後に自動削除されます（`alb.tf` の `athena_results` バケットライフサイクル設定）。
 
+#### ECSコンテナログ
+
+ECSアプリコンテナのログ（FireLens / Fluent Bit 経由）をS3へ記録し、Athenaでクエリできます。ヘルスチェックのログは除外されています。
+
+**クエリ手順**
+
+1. Athena コンソールを開く
+2. ワークグループを `{app-name}-{environment}-ecs-logs` に切替える
+3. データベース `{app_name}_{environment}_ecs_logs` → テーブル `ecs_logs` を選択
+
+```sql
+-- 特定日のログを表示
+SELECT log, container_name, source
+FROM ecs_logs
+WHERE date = '2026/05/17'
+LIMIT 50;
+
+-- エラーログの抽出
+SELECT log, container_name
+FROM ecs_logs
+WHERE date = date_format(current_date, '%Y/%m/%d')
+  AND lower(log) LIKE '%error%'
+LIMIT 50;
+```
+
 ## ドキュメント
 
 | ドキュメント | 内容 |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -110,6 +110,45 @@ LOCATION 's3://<バケット名>/AWSLogs/<AWSアカウントID>/elasticloadbalan
 
 ---
 
+## FireLens カスタムイメージのビルド＆デプロイ
+
+ECSのログルーター（Fluent Bit）はカスタムイメージを使用しています。
+`iac/aws/fluent-bit/` 配下のファイル（`extra.conf` / `remove_ansi.lua` / `Dockerfile`）を変更した場合は、イメージの再ビルドとECSサービスの再起動が必要です。
+
+### ビルド＆ECRプッシュ
+
+`iac/aws/fluent-bit/` ディレクトリで実行してください。
+
+```powershell
+$ACCOUNT_ID = (aws sts get-caller-identity | ConvertFrom-Json).Account
+$REGION = "ap-northeast-1"
+$REPO = "$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/dev/fluent-bit"
+
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin "$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com"
+docker build -t dev/fluent-bit .
+docker tag dev/fluent-bit:latest "${REPO}:latest"
+docker push "${REPO}:latest"
+```
+
+### ECSサービスの再起動（新イメージを反映）
+
+```powershell
+aws ecs update-service `
+  --cluster sandbox-aws-dev-cluster `
+  --service sandbox-aws-dev-service `
+  --force-new-deployment
+```
+
+### 設定変更時の対応フロー
+
+| 変更内容 | 必要な作業 |
+|---|---|
+| `extra.conf` / `remove_ansi.lua` の変更 | ビルド＆プッシュ → ECSサービス再起動 |
+| `Dockerfile` のベースイメージ変更 | ビルド＆プッシュ → ECSサービス再起動 |
+| ECSタスク定義（環境変数等）の変更 | `terraform apply` → ECSサービス再起動 |
+
+---
+
 ## ECS - タスク強制再デプロイ
 
 SSMパラメータストアの値を変更した場合（DATABASE_URL等）、実行中のタスクには自動反映されません。

--- a/iac/aws/athena_ecs_logs.tf
+++ b/iac/aws/athena_ecs_logs.tf
@@ -1,7 +1,6 @@
 # ECSログ用Glueデータベース
 resource "aws_glue_catalog_database" "ecs_logs" {
-  name   = "${replace(var.app-name, "-", "_")}_${var.environment}_ecs_logs"
-  bucket = aws_s3_bucket.athena_results.bucket
+  name = "${replace(var.app-name, "-", "_")}_${var.environment}_ecs_logs"
 }
 
 # ECSログ用Glueテーブル: FireLens(Fluent Bit)がS3へ書き込むJSON形式ログを定義

--- a/iac/aws/athena_ecs_logs.tf
+++ b/iac/aws/athena_ecs_logs.tf
@@ -32,7 +32,7 @@ resource "aws_glue_catalog_table" "ecs_logs" {
     location      = "s3://${aws_s3_bucket.ecs_logs.bucket}/ecs-logs/"
     input_format  = "org.apache.hadoop.mapred.TextInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
-    compressed    = true
+    compressed    = false
 
     ser_de_info {
       serialization_library = "org.openx.data.jsonserde.JsonSerDe"

--- a/iac/aws/athena_ecs_logs.tf
+++ b/iac/aws/athena_ecs_logs.tf
@@ -19,7 +19,7 @@ resource "aws_glue_catalog_table" "ecs_logs" {
     "projection.date.range"         = "NOW-1YEARS,NOW"
     "projection.date.interval"      = "1"
     "projection.date.interval.unit" = "DAYS"
-    "storage.location.template"     = "s3://${aws_s3_bucket.ecs_logs.bucket}//ecs-logs/$${date}/"
+    "storage.location.template"     = "s3://${aws_s3_bucket.ecs_logs.bucket}/ecs-logs/$${date}/"
     "classification"                = "json"
   }
 
@@ -29,7 +29,7 @@ resource "aws_glue_catalog_table" "ecs_logs" {
   }
 
   storage_descriptor {
-    location      = "s3://${aws_s3_bucket.ecs_logs.bucket}//ecs-logs/"
+    location      = "s3://${aws_s3_bucket.ecs_logs.bucket}/ecs-logs/"
     input_format  = "org.apache.hadoop.mapred.TextInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
     compressed    = true

--- a/iac/aws/athena_ecs_logs.tf
+++ b/iac/aws/athena_ecs_logs.tf
@@ -1,0 +1,86 @@
+# ECSログ用Glueデータベース
+resource "aws_glue_catalog_database" "ecs_logs" {
+  name   = "${replace(var.app-name, "-", "_")}_${var.environment}_ecs_logs"
+  bucket = aws_s3_bucket.athena_results.bucket
+}
+
+# ECSログ用Glueテーブル: FireLens(Fluent Bit)がS3へ書き込むJSON形式ログを定義
+# partition projection により MSCK REPAIR TABLE 不要で日付パーティションを自動解決
+resource "aws_glue_catalog_table" "ecs_logs" {
+  name          = "ecs_logs"
+  database_name = aws_glue_catalog_database.ecs_logs.name
+  catalog_id    = data.aws_caller_identity.self.account_id
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    "EXTERNAL"                      = "TRUE"
+    "projection.enabled"            = "true"
+    "projection.date.type"          = "date"
+    "projection.date.format"        = "yyyy/MM/dd"
+    "projection.date.range"         = "NOW-1YEARS,NOW"
+    "projection.date.interval"      = "1"
+    "projection.date.interval.unit" = "DAYS"
+    "storage.location.template"     = "s3://${aws_s3_bucket.ecs_logs.bucket}/ecs-logs/$${date}/"
+    "classification"                = "json"
+  }
+
+  partition_keys {
+    name = "date"
+    type = "string"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.ecs_logs.bucket}/ecs-logs/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    compressed    = true
+
+    ser_de_info {
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+      parameters = {
+        "ignore.malformed.json" = "true"
+      }
+    }
+
+    columns {
+      name = "container_id"
+      type = "string"
+    }
+    columns {
+      name = "container_name"
+      type = "string"
+    }
+    columns {
+      name = "source"
+      type = "string"
+    }
+    columns {
+      name = "log"
+      type = "string"
+    }
+    columns {
+      name = "ecs_cluster"
+      type = "string"
+    }
+    columns {
+      name = "ecs_task_arn"
+      type = "string"
+    }
+    columns {
+      name = "ecs_task_definition"
+      type = "string"
+    }
+  }
+}
+
+# Athenaワークグループ: ECSログクエリ用
+resource "aws_athena_workgroup" "ecs_logs" {
+  name          = "${var.app-name}-${var.environment}-ecs-logs"
+  force_destroy = true
+
+  configuration {
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.athena_results.bucket}/results/"
+    }
+  }
+}

--- a/iac/aws/athena_ecs_logs.tf
+++ b/iac/aws/athena_ecs_logs.tf
@@ -19,7 +19,7 @@ resource "aws_glue_catalog_table" "ecs_logs" {
     "projection.date.range"         = "NOW-1YEARS,NOW"
     "projection.date.interval"      = "1"
     "projection.date.interval.unit" = "DAYS"
-    "storage.location.template"     = "s3://${aws_s3_bucket.ecs_logs.bucket}/ecs-logs/$${date}/"
+    "storage.location.template"     = "s3://${aws_s3_bucket.ecs_logs.bucket}//ecs-logs/$${date}/"
     "classification"                = "json"
   }
 
@@ -29,7 +29,7 @@ resource "aws_glue_catalog_table" "ecs_logs" {
   }
 
   storage_descriptor {
-    location      = "s3://${aws_s3_bucket.ecs_logs.bucket}/ecs-logs/"
+    location      = "s3://${aws_s3_bucket.ecs_logs.bucket}//ecs-logs/"
     input_format  = "org.apache.hadoop.mapred.TextInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
     compressed    = true

--- a/iac/aws/code-pipeline-backend.tf
+++ b/iac/aws/code-pipeline-backend.tf
@@ -253,7 +253,7 @@ resource "aws_iam_role_policy" "backend-codepipeline" {
           Resource = [
             aws_ecs_cluster.cluster.arn,
             local.ecs_service_arn,
-            aws_ecs_task_definition.task_definition.arn,
+            "${aws_ecs_task_definition.task_definition.arn_without_revision}:*",
           ]
         },
         {

--- a/iac/aws/fluent-bit/Dockerfile
+++ b/iac/aws/fluent-bit/Dockerfile
@@ -1,2 +1,3 @@
 FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
 COPY extra.conf /fluent-bit/etc/extra.conf
+COPY remove_ansi.lua /fluent-bit/etc/remove_ansi.lua

--- a/iac/aws/fluent-bit/Dockerfile
+++ b/iac/aws/fluent-bit/Dockerfile
@@ -1,3 +1,3 @@
-FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
+FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:2.32.4
 COPY extra.conf /fluent-bit/etc/extra.conf
 COPY remove_ansi.lua /fluent-bit/etc/remove_ansi.lua

--- a/iac/aws/fluent-bit/extra.conf
+++ b/iac/aws/fluent-bit/extra.conf
@@ -23,7 +23,6 @@
     Match             *
     region            ${AWS_REGION}
     bucket            ${ECS_LOG_BUCKET}
-    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S.gz
-    compression       gzip
+    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S
     total_file_size   50M
     upload_timeout    10m

--- a/iac/aws/fluent-bit/extra.conf
+++ b/iac/aws/fluent-bit/extra.conf
@@ -23,7 +23,7 @@
     Match             *
     region            ${AWS_REGION}
     bucket            ${ECS_LOG_BUCKET}
-    s3_key_format     ecs-logs/%Y/%m/%d/%H%M%S
+    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S
     compression       gzip
     total_file_size   50M
     upload_timeout    10m

--- a/iac/aws/fluent-bit/extra.conf
+++ b/iac/aws/fluent-bit/extra.conf
@@ -1,4 +1,10 @@
 [FILTER]
+    Name   lua
+    Match  *
+    script /fluent-bit/etc/remove_ansi.lua
+    call   remove_ansi
+
+[FILTER]
     Name    grep
     Match   *
     Exclude log ${HEALTH_CHECK_PATH}

--- a/iac/aws/fluent-bit/extra.conf
+++ b/iac/aws/fluent-bit/extra.conf
@@ -16,6 +16,7 @@
     log_group_name    ${CW_LOG_GROUP}
     log_stream_prefix ecs/
     auto_create_group false
+    log_key           log
 
 [OUTPUT]
     Name              s3

--- a/iac/aws/fluent-bit/extra.conf
+++ b/iac/aws/fluent-bit/extra.conf
@@ -23,7 +23,7 @@
     Match             *
     region            ${AWS_REGION}
     bucket            ${ECS_LOG_BUCKET}
-    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S
+    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S.gz
     compression       gzip
     total_file_size   50M
     upload_timeout    10m

--- a/iac/aws/fluent-bit/extra.conf
+++ b/iac/aws/fluent-bit/extra.conf
@@ -23,7 +23,7 @@
     Match             *
     region            ${AWS_REGION}
     bucket            ${ECS_LOG_BUCKET}
-    s3_key_format     /ecs-logs/%Y/%m/%d/%H%M%S
+    s3_key_format     ecs-logs/%Y/%m/%d/%H%M%S
     compression       gzip
     total_file_size   50M
     upload_timeout    10m

--- a/iac/aws/fluent-bit/remove_ansi.lua
+++ b/iac/aws/fluent-bit/remove_ansi.lua
@@ -1,0 +1,6 @@
+function remove_ansi(tag, timestamp, record)
+    if record["log"] ~= nil then
+        record["log"] = record["log"]:gsub("\27%[[0-9;]*m", "")
+    end
+    return 1, timestamp, record
+end


### PR DESCRIPTION
## Summary

- FireLens（Fluent Bit）サイドカーをECSタスクに追加し、ログをCloudWatch Logs（7日保持）とS3（長期保存）に同時出力
- `/health` ヘルスチェックログを両出力先から除外
- ANSIカラーコード（`[32m` 等）をLuaフィルターで除去
- CloudWatch Logsはテキスト形式、S3はECSメタデータ付きJSON形式で出力
- カスタムFluentBitイメージ（`iac/aws/fluent-bit/`）をECRに格納する方式を採用
- ECSログ用S3バケットを追加（31日→Standard-IA、365日→Glacier）
- バックエンドDockerfileのベースイメージをECR Publicミラーに変更（Docker Hubレートリミット回避）

## 変更ファイル

- `iac/aws/ecs.tf` - ログドライバーをawslogs→awsfirelensに変更、log_routerサイドカー追加
- `iac/aws/ecs_logs.tf` - S3バケット、ECRリポジトリ、IAMポリシー追加
- `iac/aws/fluent-bit/Dockerfile` - カスタムFluentBitイメージ定義
- `iac/aws/fluent-bit/extra.conf` - フィルタ・出力先設定
- `iac/aws/fluent-bit/remove_ansi.lua` - ANSIカラーコード除去スクリプト
- `backend/sandbox-backend/Dockerfile` - ベースイメージをECR Publicミラーに変更

## 初回デプロイ手順

1. `terraform apply` でECRリポジトリ・S3バケット等を作成
2. `iac/aws/fluent-bit/` でカスタムイメージをビルド＆ECRにプッシュ
3. ECSサービスを更新してlog_router入りタスク定義を反映

## Test plan

- [x] CloudWatch Logsにテキスト形式でアプリログが出力されること
- [x] `/health` のログが除外されていること
- [x] ANSIカラーコードが除去されていること
- [x] S3バケット（ecs-logs）にJSON形式のログファイルが書き込まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)