### PR TITLE
chore: .gitignoreを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# ===== Claude Code =====
+# 個人/一時ファイルのみ無視。チーム共有設定 (.claude/settings.json, CLAUDE.md,
+# agents/, commands/, hooks/) は明示的に commit する。
+.claude/worktrees/
+.claude/settings.local.json
+.claude/projects/
+
+# ===== OS / エディタ =====
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- `.claude/` 配下の個人/一時ファイル (`worktrees/`, `settings.local.json`, `projects/`) のみ ignore
- チーム共有設定 (`settings.json`, `CLAUDE.md`, `agents/`, `commands/`, `hooks/`) はコミット対象として残す
- OS/エディタの一時ファイル (`.DS_Store`, `Thumbs.db`, `*.swp`, `.vscode/`, `.idea/`) を追加

これまでリポジトリルートに `.gitignore` が無く、Claude Code のワークツリーやエディタ一時ファイルが毎回 `git status` に出ていたのを解消する。

## Test plan
- [ ] `git status` で `.claude/worktrees/` や `.vscode/` 等が表示されないこと
- [ ] 既存のサブディレクトリ `.gitignore` (`iac/.gitignore`, `backend/sandbox-backend/.gitignore`, `frontend/sandbox-frontend/.gitignore`) と競合しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)