### PR TITLE
feat: CloudWatchアラーム・CloudFrontログ・WAFを追加

### DIFF
--- a/iac/aws/cloudfront.tf
+++ b/iac/aws/cloudfront.tf
@@ -27,6 +27,8 @@ resource "aws_cloudfront_distribution" "cdn" {
   is_ipv6_enabled = true
   price_class     = "PriceClass_100"
   tags            = {}
+  # AWS WAF v2 (CLOUDFRONT scope, us-east-1) をアタッチ。詳細は waf.tf
+  web_acl_id = aws_wafv2_web_acl.cloudfront.arn
 
   default_cache_behavior {
     allowed_methods = [

--- a/iac/aws/cloudfront_logs.tf
+++ b/iac/aws/cloudfront_logs.tf
@@ -1,0 +1,120 @@
+# CloudFront 標準アクセスログ (v2 CloudWatch Logs Delivery 経由でS3配信)
+#
+# レガシー方式 (aws_cloudfront_distribution.logging_config) はS3バケットにACL有効化と
+# `awslogsdelivery@amazon.com` への ACL grant が必須で、本プロジェクトの
+# `block_public_acls = true` ポリシーと噛み合わない。
+# よって v2 方式 (aws_cloudwatch_log_delivery_*) を採用 — バケットポリシーのみで配信可能。
+#
+# 注意: CloudFront は us-east-1 リージョンの API で管理されるため、
+# log_delivery_source / destination / delivery の3リソースはすべて us-east-1 プロバイダを使う。
+# S3バケット自体は ap-northeast-1 のままで問題ない (リージョン間配信可)。
+
+# CloudFrontアクセスログ用S3バケット
+resource "aws_s3_bucket" "cloudfront_logs" {
+  bucket        = "${var.app-name}-${var.environment}-cf-logs-${random_string.suffix.result}"
+  force_destroy = true
+  tags          = {}
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
+  bucket                  = aws_s3_bucket.cloudfront_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Standard → Standard-IA(31日) → Glacier(365日) でALB/ECSログと同じ階層化
+resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+  rule {
+    id     = "tiering"
+    status = "Enabled"
+    filter {}
+    transition {
+      days          = 31
+      storage_class = "STANDARD_IA"
+    }
+    transition {
+      days          = 365
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+# CloudWatch Logs Delivery がバケットに書き込むための権限
+# (delivery.logs.amazonaws.com サービスプリンシパルに対する PutObject / GetBucketAcl 等)
+resource "aws_s3_bucket_policy" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowLogDeliveryWrite"
+        Effect    = "Allow"
+        Principal = { Service = "delivery.logs.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.cloudfront_logs.arn}/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl"      = "bucket-owner-full-control"
+            "aws:SourceAccount" = data.aws_caller_identity.self.account_id
+          }
+        }
+      },
+      {
+        Sid       = "AllowLogDeliveryAclCheck"
+        Effect    = "Allow"
+        Principal = { Service = "delivery.logs.amazonaws.com" }
+        Action    = ["s3:GetBucketAcl", "s3:ListBucket"]
+        Resource  = aws_s3_bucket.cloudfront_logs.arn
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.self.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+# CloudFrontディストリビューションをログ配信元として登録
+# (CloudFrontがグローバルサービスのため us-east-1 で作成)
+resource "aws_cloudwatch_log_delivery_source" "cloudfront" {
+  provider     = aws.us_east_1
+  name         = "${var.app-name}-${var.environment}-cf-access-source"
+  log_type     = "ACCESS_LOGS"
+  resource_arn = aws_cloudfront_distribution.cdn.arn
+}
+
+# S3を配信先として登録 (parquetフォーマット: Athenaでの効率的なクエリ用)
+resource "aws_cloudwatch_log_delivery_destination" "cloudfront" {
+  provider      = aws.us_east_1
+  name          = "${var.app-name}-${var.environment}-cf-access-dest"
+  output_format = "parquet"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_s3_bucket.cloudfront_logs.arn
+  }
+}
+
+# 配信元と配信先を紐付け
+# suffix_path で年月日時パーティションをS3キーに含める (Athena partition projection 用)
+resource "aws_cloudwatch_log_delivery" "cloudfront" {
+  provider                 = aws.us_east_1
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.cloudfront.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cloudfront.arn
+
+  s3_delivery_configuration {
+    suffix_path                 = "AWSLogs/${data.aws_caller_identity.self.account_id}/CloudFront/${aws_cloudfront_distribution.cdn.id}/{yyyy}/{MM}/{dd}/{HH}"
+    enable_hive_compatible_path = false
+  }
+
+  depends_on = [aws_s3_bucket_policy.cloudfront_logs]
+}
+
+# NOTE: AthenaクエリのためのGlueカタログテーブルは別途追加可能。
+# v2 logging (parquet) は CloudFront 標準ログのフィールド名 (cs-method, cs(Host) 等) を
+# そのままparquetカラム名として使うため、Athenaクエリ時にバッククォートでのエスケープが必要。
+# 初期配信後に実際のparquetスキーマをglue crawlerで確認し、
+# 必要に応じてATHena DDL (`athena_cloudfront_logs.tf`) を後追いで作成する想定。

--- a/iac/aws/cloudwatch_alarms.tf
+++ b/iac/aws/cloudwatch_alarms.tf
@@ -1,0 +1,191 @@
+# CloudWatchアラーム集約: ECS / Aurora の異常検知用
+#
+# 通知先: aws_sns_topic.alarms (本ファイルで作成)
+# サブスクリプション(Email/Slack/Lambda等)は本Terraformでは作成せず、AWSコンソールから手動で登録する想定。
+
+# アラーム閾値: 1ヶ所で管理し、ACU上限変更時等に調整しやすくする
+# Aurora Serverless v2 の動的指標は ACU 連動で変化する点に注意。
+#   - 1 ACU ≒ 2 GiBメモリ・最大接続数 約90 (DBInstanceClassMemory/9,531,392 = 約90)
+#   - FreeLocalStorage は ACU 連動で数GiB〜
+locals {
+  alarm_eval_periods      = 2  # 連続2回しきい値を超えたら通知(瞬間スパイクの誤検知抑制)
+  alarm_period_seconds    = 60 # メトリクス評価間隔(秒)
+  alarm_cpu_threshold_pct = 80 # CPU使用率しきい値(ECS/Aurora共通)
+  alarm_memory_util_pct   = 80 # ECS MemoryUtilization 使用率しきい値 (= 残20%で通知)
+  alarm_acu_util_pct      = 80 # Aurora ACUUtilization (Serverless v2のCPU+メモリ複合指標)
+
+  # Aurora Serverless v2 (max_capacity=1.0 ACU = 約2GiBメモリ) 想定
+  alarm_aurora_freeable_memory_bytes  = 209715200    # 200 MiB を下回ったら通知(残10%)
+  alarm_aurora_connections_threshold  = 70           # 1 ACU 最大約90に対する警告線
+  alarm_aurora_free_local_storage     = 536870912    # 512 MiB を下回ったら通知
+  alarm_aurora_volume_bytes_threshold = 107374182400 # 100 GiB を超えたら通知(コスト監視)
+}
+
+# 全アラーム共通の通知先SNSトピック
+# サブスクライバ(Email/Slack/Lambda等)はAWSコンソールから手動登録する
+resource "aws_sns_topic" "alarms" {
+  name = "${var.app-name}-${var.environment}-alarms"
+}
+
+# ---------- ECS タスク(サービスレベル指標) ----------
+# AWS/ECS 名前空間の CPUUtilization / MemoryUtilization は ECSサービスが標準で出力(Container Insights不要)。
+# Dimensions は ClusterName + ServiceName。
+
+# ECS CPU使用率 > 80%
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_high" {
+  alarm_name          = "${var.app-name}-${var.environment}-ecs-cpu-high"
+  alarm_description   = "ECSサービスのCPU使用率が${local.alarm_cpu_threshold_pct}%を超過"
+  namespace           = "AWS/ECS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+  period              = local.alarm_period_seconds
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_cpu_threshold_pct
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    ClusterName = aws_ecs_cluster.cluster.name
+    ServiceName = aws_ecs_service.service.name
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# ECS メモリ使用率 > 80% (= メモリ残りが20%未満)
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_high" {
+  alarm_name          = "${var.app-name}-${var.environment}-ecs-memory-high"
+  alarm_description   = "ECSサービスのメモリ使用率が${local.alarm_memory_util_pct}%を超過(残り20%未満)"
+  namespace           = "AWS/ECS"
+  metric_name         = "MemoryUtilization"
+  statistic           = "Average"
+  period              = local.alarm_period_seconds
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_memory_util_pct
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    ClusterName = aws_ecs_cluster.cluster.name
+    ServiceName = aws_ecs_service.service.name
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# ---------- Aurora PostgreSQL Serverless v2 ----------
+# DBClusterIdentifier または DBInstanceIdentifier をDimensionsに指定。
+# - インスタンスレベル指標: CPUUtilization, FreeableMemory, DatabaseConnections, FreeLocalStorage, ACUUtilization
+# - クラスタレベル指標   : VolumeBytesUsed
+
+# Aurora コネクション枯渇(1 ACU上限 約90に対する警告)
+resource "aws_cloudwatch_metric_alarm" "aurora_connections_high" {
+  alarm_name          = "${var.app-name}-${var.environment}-aurora-connections-high"
+  alarm_description   = "Auroraコネクション数が${local.alarm_aurora_connections_threshold}を超過(枯渇間近)"
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  statistic           = "Maximum"
+  period              = local.alarm_period_seconds
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_aurora_connections_threshold
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    DBInstanceIdentifier = aws_rds_cluster_instance.instance.identifier
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Aurora CPU使用率 > 80%
+resource "aws_cloudwatch_metric_alarm" "aurora_cpu_high" {
+  alarm_name          = "${var.app-name}-${var.environment}-aurora-cpu-high"
+  alarm_description   = "AuroraインスタンスのCPU使用率が${local.alarm_cpu_threshold_pct}%を超過"
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+  period              = local.alarm_period_seconds
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_cpu_threshold_pct
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    DBInstanceIdentifier = aws_rds_cluster_instance.instance.identifier
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Aurora ACU使用率 > 80% (Serverless v2のCPU/メモリ複合指標 — スケール上限張り付き検知)
+resource "aws_cloudwatch_metric_alarm" "aurora_acu_high" {
+  alarm_name          = "${var.app-name}-${var.environment}-aurora-acu-high"
+  alarm_description   = "Aurora ACU使用率が${local.alarm_acu_util_pct}%を超過(max_capacity張り付き間近)"
+  namespace           = "AWS/RDS"
+  metric_name         = "ACUUtilization"
+  statistic           = "Average"
+  period              = local.alarm_period_seconds
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_acu_util_pct
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    DBInstanceIdentifier = aws_rds_cluster_instance.instance.identifier
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Aurora 利用可能メモリ < 200 MiB (max_capacity=1.0 ACU=約2GiB 想定 / 残10%)
+resource "aws_cloudwatch_metric_alarm" "aurora_freeable_memory_low" {
+  alarm_name          = "${var.app-name}-${var.environment}-aurora-freeable-memory-low"
+  alarm_description   = "Aurora FreeableMemoryが${local.alarm_aurora_freeable_memory_bytes}バイトを下回った"
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeableMemory"
+  statistic           = "Average"
+  period              = local.alarm_period_seconds
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_aurora_freeable_memory_bytes
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    DBInstanceIdentifier = aws_rds_cluster_instance.instance.identifier
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Aurora ローカル一時SSD残量 < 512 MiB (一時テーブル/ソート溢れの検知)
+resource "aws_cloudwatch_metric_alarm" "aurora_free_local_storage_low" {
+  alarm_name          = "${var.app-name}-${var.environment}-aurora-local-storage-low"
+  alarm_description   = "Aurora FreeLocalStorageが${local.alarm_aurora_free_local_storage}バイトを下回った"
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeLocalStorage"
+  statistic           = "Minimum"
+  period              = local.alarm_period_seconds
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_aurora_free_local_storage
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    DBInstanceIdentifier = aws_rds_cluster_instance.instance.identifier
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# Aurora クラスタストレージ利用量 > 100 GiB (本体ストレージは128TiBまで自動拡張するため "残量低下" ではなく "利用量増大によるコスト監視" 用途)
+resource "aws_cloudwatch_metric_alarm" "aurora_volume_bytes_high" {
+  alarm_name          = "${var.app-name}-${var.environment}-aurora-volume-bytes-high"
+  alarm_description   = "Auroraクラスタストレージが${local.alarm_aurora_volume_bytes_threshold}バイトを超過(コスト確認)"
+  namespace           = "AWS/RDS"
+  metric_name         = "VolumeBytesUsed"
+  statistic           = "Maximum"
+  period              = 300 # クラスタ指標は5分粒度で十分
+  evaluation_periods  = local.alarm_eval_periods
+  threshold           = local.alarm_aurora_volume_bytes_threshold
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.cluster.cluster_identifier
+  }
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}

--- a/iac/aws/provider.tf
+++ b/iac/aws/provider.tf
@@ -3,6 +3,15 @@ provider "aws" {
   region = "ap-northeast-1"
 }
 
+# CloudFront標準ログ(v2 CloudWatch Logs Delivery)用のus-east-1プロバイダ
+# CloudFrontはグローバルサービスで、APIエンドポイントが us-east-1 に固定されている。
+# aws_cloudwatch_log_delivery_source/destination/delivery 三点セットは CloudFront と同じリージョン(us-east-1)に配置する必要がある。
+# (配信先S3バケット自体は ap-northeast-1 のままで問題ない)
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
 # Auth0プロバイダ: テナント情報を環境変数(terraform.tfvars)から注入
 provider "auth0" {
   domain        = var.auth0_domain

--- a/iac/aws/waf.tf
+++ b/iac/aws/waf.tf
@@ -1,0 +1,192 @@
+# AWS WAF v2 (CloudFront用): CloudFrontディストリビューションへアタッチして
+# 一般的な攻撃パターンを遮断する。
+#
+# 配置リージョン: us-east-1
+#   - scope = "CLOUDFRONT" の WAF は us-east-1 でしか作れない
+#   - WAFログ配信先S3バケットも同じ us-east-1 でないと直接配信できない
+#   - そのため WAF 関連リソース + WAFログ用S3バケットはすべて `aws.us_east_1` プロバイダで作成
+#
+# ルール構成 (デフォルトルール: AWSマネージドルールグループ 3種):
+#   1. AWSManagedRulesCommonRuleSet         (OWASP Top10系の汎用攻撃検知)
+#   2. AWSManagedRulesKnownBadInputsRuleSet (既知の悪性ペイロード検知)
+#   3. AWSManagedRulesAmazonIpReputationList(AWS収集の悪性IP遮断)
+# default_action = allow (ルールにマッチしたものだけブロック)
+
+resource "aws_wafv2_web_acl" "cloudfront" {
+  provider = aws.us_east_1
+  name     = "${var.app-name}-${var.environment}-cf-acl"
+  scope    = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  # ルール1: 一般的な攻撃パターン (XSS / SQLi / LFI 等)
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 10
+
+    override_action {
+      none {} # マネージドルールグループ既定のアクション(主にblock)をそのまま使う
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # ルール2: 既知の悪性ペイロード (Log4Shell 等含む)
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 20
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # ルール3: AWS収集の悪性IPレピュテーションリスト
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.app-name}-${var.environment}-cf-acl"
+    sampled_requests_enabled   = true
+  }
+}
+
+# WAFログ用S3バケット (us-east-1)
+#
+# 重要制約:
+#   - バケット名は "aws-waf-logs-" プレフィックスで開始すること (AWS WAFの仕様)
+#   - WAF (CLOUDFRONT scope) と同リージョン (us-east-1) であること
+resource "aws_s3_bucket" "waf_logs" {
+  provider      = aws.us_east_1
+  bucket        = "aws-waf-logs-${var.app-name}-${var.environment}-${random_string.suffix.result}"
+  force_destroy = true
+  tags          = {}
+}
+
+resource "aws_s3_bucket_public_access_block" "waf_logs" {
+  provider                = aws.us_east_1
+  bucket                  = aws_s3_bucket.waf_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Standard → Standard-IA(31日) → Glacier(365日) でALB/ECS/CFログと同じ階層化
+resource "aws_s3_bucket_lifecycle_configuration" "waf_logs" {
+  provider = aws.us_east_1
+  bucket   = aws_s3_bucket.waf_logs.id
+  rule {
+    id     = "tiering"
+    status = "Enabled"
+    filter {}
+    transition {
+      days          = 31
+      storage_class = "STANDARD_IA"
+    }
+    transition {
+      days          = 365
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+# WAFログ配信用バケットポリシー
+# (delivery.logs.amazonaws.com に PutObject / GetBucketAcl を許可)
+resource "aws_s3_bucket_policy" "waf_logs" {
+  provider = aws.us_east_1
+  bucket   = aws_s3_bucket.waf_logs.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AWSLogDeliveryWrite"
+        Effect    = "Allow"
+        Principal = { Service = "delivery.logs.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.waf_logs.arn}/AWSLogs/${data.aws_caller_identity.self.account_id}/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl"      = "bucket-owner-full-control"
+            "aws:SourceAccount" = data.aws_caller_identity.self.account_id
+          }
+        }
+      },
+      {
+        Sid       = "AWSLogDeliveryAclCheck"
+        Effect    = "Allow"
+        Principal = { Service = "delivery.logs.amazonaws.com" }
+        Action    = "s3:GetBucketAcl"
+        Resource  = aws_s3_bucket.waf_logs.arn
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.self.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+# WAF → S3 ログ配信設定
+# log_destination_configs に S3バケットARNを指定すれば Firehose 不要で直接配信
+resource "aws_wafv2_web_acl_logging_configuration" "cloudfront" {
+  provider                = aws.us_east_1
+  log_destination_configs = [aws_s3_bucket.waf_logs.arn]
+  resource_arn            = aws_wafv2_web_acl.cloudfront.arn
+
+  depends_on = [aws_s3_bucket_policy.waf_logs]
+}
+
+# NOTE: WAFログ用のAthena/Glueテーブルは別途追加可能。
+# WAFログはJSON形式で 1行1リクエスト・スキーマがマネージドルール構成に依存するため、
+# 初期配信後に実データを確認してから JsonSerDe ベースの Glue テーブルを後追いで作成する想定。
+# また Athena ワークグループ自体が ap-northeast-1 にしか無いため、
+# クロスリージョンクエリ(us-east-1のバケットを直接クエリ)か、
+# us-east-1 にも Athena ワークグループを作るか、要判断。


### PR DESCRIPTION
## Summary
監視/ロギング/WAF を一式追加。`terraform apply` 動作確認済み (ECS/Aurora アラームと SNS トピック、CloudFront アクセスログ、WAF + WAF ログ)。

### 1. CloudWatch アラーム + SNS (`iac/aws/cloudwatch_alarms.tf`)
SNS トピック `${app-name}-${env}-alarms` を作成し、アラーム 8 件をぶら下げる。サブスクライバ (Email/Slack/Lambda 等) はコンソールから手動登録する想定。

- **ECS**: `CPUUtilization > 80%`、`MemoryUtilization > 80%`
- **Aurora (Serverless v2)**:
  - `DatabaseConnections > 70` (1 ACU 上限約90に対する警告)
  - `CPUUtilization > 80%`
  - `ACUUtilization > 80%` (max_capacity 張り付き間近)
  - `FreeableMemory < 200 MiB`
  - `FreeLocalStorage < 512 MiB`
  - `VolumeBytesUsed > 100 GiB` (コスト監視)

しきい値は `locals` 1ヶ所に集約。`max_capacity` 変更時にここを見直す。

### 2. CloudFront アクセスログ (`iac/aws/cloudfront_logs.tf`)
v2 CloudWatch Logs Delivery で S3 へ parquet 配信。レガシー方式と異なり ACL 不要 (`block_public_acls = true` 維持可)。
- 配信元 (CloudFront) は us-east-1 API 管理のため `aws.us_east_1` プロバイダで配信3点セットを作成
- 配信先 S3 バケットは ap-northeast-1
- ALB/ECS ログと同じ 31日/365日 ライフサイクル

### 3. AWS WAF v2 (`iac/aws/waf.tf`)
CloudFront に WebACL をアタッチ。マネージドルール3種:
- `AWSManagedRulesCommonRuleSet` (OWASP Top10系)
- `AWSManagedRulesKnownBadInputsRuleSet` (Log4Shell 等)
- `AWSManagedRulesAmazonIpReputationList` (悪性IP)

WAF ログは S3 直接配信 (Firehose 不要)。バケットは `aws-waf-logs-` プレフィックス + us-east-1 制約。

### 4. プロバイダ追加 (`iac/aws/provider.tf`)
`aws.us_east_1` エイリアスを追加 (CloudFront ログ・WAF で使用)。

### 5. CloudFront 側変更 (`iac/aws/cloudfront.tf`)
WebACL のアタッチを 2 行追加。

## Test plan
- [x] `terraform validate` OK
- [x] `terraform apply` 成功
- [x] SNS トピックにサブスクリプション登録 + 確認メール承認済み
- [x] CloudWatch コンソールでアラーム 8 件が `OK` または `INSUFFICIENT_DATA` で表示されること
- [x] `aws cloudwatch set-alarm-state --alarm-name <name> --state-value ALARM --state-reason test` で疎通確認
- [x] CloudFront 経由のリクエストが WAF で誤ブロックされていないか、AWS WAF コンソールの「サンプリングされたリクエスト」で確認
- [ ] 数日後 S3 バケット (`*-cf-logs-*`, `aws-waf-logs-*`) にログオブジェクトが届いていること

## 既知の TODO (本PRスコープ外)
- CloudFront / WAF ログ用 Athena/Glue テーブル (parquet スキーマ実データ確認後に追加)
- `docs/iac-spec.md` / `docs/iac-architecture-diagram.md` への追記
- WAF マネージドルールの誤検知が出た場合は `rule_action_override` で count モード化

🤖 Generated with [Claude Code](https://claude.com/claude-code)