### PR TITLE
feat(ci): フロントエンド・バックエンドのTrivyセキュリティスキャンを追加

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -1,0 +1,77 @@
+name: CI - Backend (Trivy + ECR scan)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/ci-backend.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BACKEND_DIR: backend/sandbox-backend
+  IMAGE_NAME: sandbox-backend:ci-${{ github.sha }}
+
+jobs:
+  trivy-fs:
+    name: Trivy fs scan (deps + secrets)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trivy vulnerability scan (yarn.lock)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: ${{ env.BACKEND_DIR }}
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+      - name: Trivy secret scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: ${{ env.BACKEND_DIR }}
+          scanners: secret
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: '1'
+          format: table
+
+  trivy-image:
+    name: Trivy image scan (Docker build, no push)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (load to local daemon)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.BACKEND_DIR }}
+          file: ${{ env.BACKEND_DIR }}/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: ${{ env.IMAGE_NAME }}
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -1,0 +1,42 @@
+name: CI - Frontend (Trivy scan)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/ci-frontend.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-scan:
+    name: Trivy fs scan (deps + secrets)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trivy vulnerability scan (yarn.lock)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: frontend/sandbox-frontend
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+      - name: Trivy secret scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: frontend/sandbox-frontend
+          scanners: secret
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: '1'
+          format: table


### PR DESCRIPTION
## Summary
- フロントエンド (React/Vite): `ci-frontend.yaml` を追加 — Trivy fs スキャンで依存関係 (yarn.lock) の CVE とシークレットを検出
- バックエンド (NestJS/Docker): `ci-backend.yaml` を追加 — fs スキャン + Docker イメージビルド & Trivy image スキャン
- ECR の `scan_on_push = true` (既設) と組み合わせた二重防御構成

## Trigger
- `main` 宛 Pull Request（各ディレクトリ配下の変更時のみ起動）
- `workflow_dispatch`（手動実行）

## Test plan
- [ ] PR を作成して ci-frontend / ci-backend ワークフローが起動することを確認
- [ ] 脆弱性が CRITICAL/HIGH で検出された場合に exit-code 1 でジョブが失敗することを確認
- [ ] `ignore-unfixed: true` により修正版未リリースの CVE はスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)