### PR TITLE
fix(ci): workflow_dispatchをjinka1997のみに制限

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -19,6 +19,7 @@ jobs:
   trivy-fs:
     name: Trivy fs scan (deps + secrets)
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997'
 
     steps:
       - name: Checkout repository
@@ -48,6 +49,7 @@ jobs:
   trivy-image:
     name: Trivy image scan (Docker build, no push)
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -15,6 +15,7 @@ jobs:
   trivy-scan:
     name: Trivy fs scan (deps + secrets)
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- `workflow_dispatch` による手動実行を `jinka1997` アカウントのみに制限
- `github.actor` の判定を各ジョブの `if` 条件に追加
- PR トリガーは全ユーザーが対象のまま変更なし

## 動作
| トリガー | 挙動 |
|---|---|
| PR (main宛) | 誰でも起動する |
| `workflow_dispatch` (手動) | `jinka1997` のみジョブ実行 |
| `workflow_dispatch` (他ユーザー) | ジョブが `skipped` になり何もしない |

## Test plan
- [ ] `jinka1997` アカウントで手動実行 → ジョブが起動することを確認
- [ ] 別アカウントで手動実行 → ジョブが `skipped` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)