### PR TITLE
fix(ci): trivy-actionのバージョンをv0.36.0に修正

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Trivy vulnerability scan (yarn.lock)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: ${{ env.BACKEND_DIR }}
@@ -37,7 +37,7 @@ jobs:
           format: table
 
       - name: Trivy secret scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: ${{ env.BACKEND_DIR }}
@@ -68,7 +68,7 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}
 
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Trivy vulnerability scan (yarn.lock)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: frontend/sandbox-frontend
@@ -33,7 +33,7 @@ jobs:
           format: table
 
       - name: Trivy secret scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: frontend/sandbox-frontend


### PR DESCRIPTION
## Summary
- `aquasecurity/trivy-action@0.28.0` は存在しないバージョンだったため `v0.36.0`（最新）に修正

## Test plan
- [ ] Actions タブから手動実行して Trivy スキャンが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)