### PR TITLE
fix: フロントエンド・バックエンドの脆弱性修正とCI設定更新

### DIFF
--- a/backend/sandbox-backend/package.json
+++ b/backend/sandbox-backend/package.json
@@ -81,6 +81,9 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.3"
   },
+  "resolutions": {
+    "**/@opentelemetry/otlp-transformer/protobufjs": "^8.4.2"
+  },
   "jest": {
     "moduleFileExtensions": [
       "js",

--- a/backend/sandbox-backend/yarn.lock
+++ b/backend/sandbox-backend/yarn.lock
@@ -1996,17 +1996,17 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
   integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
 
-"@protobufjs/codegen@^2.0.4", "@protobufjs/codegen@^2.0.5":
+"@protobufjs/codegen@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
   integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
 
-"@protobufjs/eventemitter@^1.1.0", "@protobufjs/eventemitter@^1.1.1":
+"@protobufjs/eventemitter@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
   integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
-"@protobufjs/fetch@^1.1.0", "@protobufjs/fetch@^1.1.1":
+"@protobufjs/fetch@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
   integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
@@ -2018,7 +2018,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
   integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
 
-"@protobufjs/inquire@^1.1.0", "@protobufjs/inquire@^1.1.2":
+"@protobufjs/inquire@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
   integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
@@ -2033,7 +2033,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
   integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
 
-"@protobufjs/utf8@^1.1.0", "@protobufjs/utf8@^1.1.1":
+"@protobufjs/utf8@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
   integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
@@ -6111,23 +6111,12 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-protobufjs@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-8.0.1.tgz#c1781abf9a73812cbd483b32138ac59948223806"
-  integrity sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==
+protobufjs@8.0.1, protobufjs@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-8.4.2.tgz#758b5ed274b8d859f95174cbdb569f359a804e29"
+  integrity sha512-64rfNzkWOZAIazXzpBFPWq6F9up6gMvTzjE2oWIzApx2N/dqVUEE7+bCn2+40780dFVtKOUab8QfxJ6KJDWbqA==
   dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
+    long "^5.3.2"
 
 protobufjs@^7.5.5:
   version "7.6.1"


### PR DESCRIPTION
## Summary
- CI ワークフローの trivy-action バージョン修正・手動実行制限
- フロントエンド / バックエンドの HIGH/CRITICAL 脆弱性をすべて解消

## 変更内容

### CI
- `trivy-action` のバージョンを `0.28.0`(存在しない) → `v0.36.0` に修正
- `workflow_dispatch` による手動実行を `jinka1997` アカウントのみに制限

### Frontend (`frontend/sandbox-frontend/yarn.lock`)
- `yarn upgrade` で全依存関係を更新
- lodash 4.17.21→4.18.1 (CVE-2026-4800)、react-router-dom 更新で path-to-regexp 脆弱性を解消

### Backend (`backend/sandbox-backend/`)
- `yarn upgrade` で multer・jws・validator・protobufjs 等を更新
- OpenTelemetry パッケージを exact pin から更新 (auto-instrumentations-node 0.67.0→0.75.0 等)
- `resolutions` で `@opentelemetry/otlp-transformer` の protobufjs ピンを 8.0.1→8.4.2 に強制 (CVE-2026-44289/44290/44291/44293)

## Test plan
- [ ] `ci-frontend.yaml` の Trivy fs scan が Pass することを確認
- [ ] `ci-backend.yaml` の Trivy fs scan が Pass することを確認
- [ ] `ci-backend.yaml` の Trivy image scan が Pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)