### PR TITLE
feat(ci): CIの実行結果をSlack Incoming Webhookで通知

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -77,3 +77,38 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
           format: table
+
+  notify-slack:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    needs: [trivy-fs, trivy-image]
+    if: always() && (github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997')
+
+    steps:
+      - name: Set notification vars
+        env:
+          JOB_FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [[ "$JOB_FAILED" == "true" ]]; then
+            echo "RESULT=:x: Failed" >> "$GITHUB_ENV"
+            echo "COLOR=danger" >> "$GITHUB_ENV"
+          else
+            echo "RESULT=:white_check_mark: Passed" >> "$GITHUB_ENV"
+            echo "COLOR=good" >> "$GITHUB_ENV"
+          fi
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "${{ env.COLOR }}",
+                  "mrkdwn_in": ["text"],
+                  "text": "${{ env.RESULT }} *CI - Backend (Trivy)*\n*Repo:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}` | *Commit:* `${{ github.sha }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                }
+              ]
+            }

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -41,3 +41,38 @@ jobs:
           severity: CRITICAL,HIGH,MEDIUM
           exit-code: '1'
           format: table
+
+  notify-slack:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    needs: [trivy-scan]
+    if: always() && (github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997')
+
+    steps:
+      - name: Set notification vars
+        env:
+          JOB_FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [[ "$JOB_FAILED" == "true" ]]; then
+            echo "RESULT=:x: Failed" >> "$GITHUB_ENV"
+            echo "COLOR=danger" >> "$GITHUB_ENV"
+          else
+            echo "RESULT=:white_check_mark: Passed" >> "$GITHUB_ENV"
+            echo "COLOR=good" >> "$GITHUB_ENV"
+          fi
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "${{ env.COLOR }}",
+                  "mrkdwn_in": ["text"],
+                  "text": "${{ env.RESULT }} *CI - Frontend (Trivy)*\n*Repo:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}` | *Commit:* `${{ github.sha }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary

- `ci-frontend.yaml` と `ci-backend.yaml` に `notify-slack` ジョブを追加
- Trivy スキャンの成功・失敗に関わらず常に通知（`if: always()`）
- Slack Incoming Webhook（`SLACK_WEBHOOK_URL` シークレット）を使用
- メッセージにはステータス（✅/❌）、リポジトリ名、ブランチ名、コミット SHA、Run URL を含む

## 事前設定（マージ前に対応が必要）

GitHub リポジトリの **Settings → Secrets and variables → Actions** に以下のシークレットを登録してください：

| Name | Value |
|------|-------|
| `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL |

Slack アプリの作成・Webhook URL の取得は [Slack API](https://api.slack.com/messaging/webhooks) から行えます。

## Test plan

- [ ] `SLACK_WEBHOOK_URL` シークレットを登録済みであることを確認
- [ ] PR を作成し、CI が通ったあとに Slack へ通知が届くことを確認
- [ ] Trivy スキャンが失敗した場合に ❌ 赤帯で通知されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)