### PR TITLE
feat(ci): Slack通知にHIGH/CRITICAL脆弱性件数を追加

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -20,12 +20,35 @@ jobs:
     name: Trivy fs scan (deps + secrets)
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997'
+    outputs:
+      vuln-high: ${{ steps.vuln-count.outputs.high }}
+      vuln-critical: ${{ steps.vuln-count.outputs.critical }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Trivy vulnerability scan (yarn.lock)
+      - name: Trivy vulnerability scan (JSON for counts)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: ${{ env.BACKEND_DIR }}
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+          format: json
+          output: trivy-vuln.json
+
+      - name: Parse vulnerability counts
+        id: vuln-count
+        run: |
+          HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' trivy-vuln.json 2>/dev/null || echo 0)
+          CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' trivy-vuln.json 2>/dev/null || echo 0)
+          echo "high=$HIGH" >> "$GITHUB_OUTPUT"
+          echo "critical=$CRITICAL" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy vulnerability scan (table + gate)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
@@ -50,6 +73,9 @@ jobs:
     name: Trivy image scan (Docker build, no push)
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997'
+    outputs:
+      vuln-high: ${{ steps.vuln-count.outputs.high }}
+      vuln-critical: ${{ steps.vuln-count.outputs.critical }}
 
     steps:
       - name: Checkout repository
@@ -67,7 +93,27 @@ jobs:
           load: true
           tags: ${{ env.IMAGE_NAME }}
 
-      - name: Trivy image scan
+      - name: Trivy image scan (JSON for counts)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ env.IMAGE_NAME }}
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+          format: json
+          output: trivy-image.json
+
+      - name: Parse vulnerability counts
+        id: vuln-count
+        run: |
+          HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' trivy-image.json 2>/dev/null || echo 0)
+          CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' trivy-image.json 2>/dev/null || echo 0)
+          echo "high=$HIGH" >> "$GITHUB_OUTPUT"
+          echo "critical=$CRITICAL" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy image scan (table + gate)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
@@ -108,7 +154,7 @@ jobs:
                 {
                   "color": "${{ env.COLOR }}",
                   "mrkdwn_in": ["text"],
-                  "text": "${{ env.RESULT }} *CI - Backend (Trivy)*\n*Repo:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}` | *Commit:* `${{ github.sha }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                  "text": "${{ env.RESULT }} *CI - Backend (Trivy)*\n*Repo:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}` | *Commit:* `${{ github.sha }}`\n*Vulns (fixable):* deps — CRITICAL: ${{ needs.trivy-fs.outputs.vuln-critical }}, HIGH: ${{ needs.trivy-fs.outputs.vuln-high }} | image — CRITICAL: ${{ needs.trivy-image.outputs.vuln-critical }}, HIGH: ${{ needs.trivy-image.outputs.vuln-high }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
                 }
               ]
             }

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -16,12 +16,35 @@ jobs:
     name: Trivy fs scan (deps + secrets)
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_dispatch' || github.actor == 'jinka1997'
+    outputs:
+      vuln-high: ${{ steps.vuln-count.outputs.high }}
+      vuln-critical: ${{ steps.vuln-count.outputs.critical }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Trivy vulnerability scan (yarn.lock)
+      - name: Trivy vulnerability scan (JSON for counts)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: frontend/sandbox-frontend
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+          format: json
+          output: trivy-vuln.json
+
+      - name: Parse vulnerability counts
+        id: vuln-count
+        run: |
+          HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' trivy-vuln.json 2>/dev/null || echo 0)
+          CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' trivy-vuln.json 2>/dev/null || echo 0)
+          echo "high=$HIGH" >> "$GITHUB_OUTPUT"
+          echo "critical=$CRITICAL" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy vulnerability scan (table + gate)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
@@ -72,7 +95,7 @@ jobs:
                 {
                   "color": "${{ env.COLOR }}",
                   "mrkdwn_in": ["text"],
-                  "text": "${{ env.RESULT }} *CI - Frontend (Trivy)*\n*Repo:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}` | *Commit:* `${{ github.sha }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                  "text": "${{ env.RESULT }} *CI - Frontend (Trivy)*\n*Repo:* ${{ github.repository }}\n*Branch:* `${{ github.ref_name }}` | *Commit:* `${{ github.sha }}`\n*Vulns (fixable):* CRITICAL: ${{ needs.trivy-scan.outputs.vuln-critical }}, HIGH: ${{ needs.trivy-scan.outputs.vuln-high }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
                 }
               ]
             }


### PR DESCRIPTION
## Summary

- Trivy の fs/image スキャンを JSON 出力で追加実行し、`jq` で CRITICAL/HIGH 件数をカウント
- job outputs 経由で `notify-slack` ジョブに件数を渡す
- Slack メッセージに `Vulns (fixable): CRITICAL: X, HIGH: Y` を追加
  - バックエンドは deps (yarn.lock) と image (Docker) を分けて表示

## 通知メッセージ例（失敗時）

```
❌ CI - Backend (Trivy)
Repo: extra-fe/template-spa-webapp
Branch: `feat/xxx` | Commit: `abc1234`
Vulns (fixable): deps — CRITICAL: 0, HIGH: 1 | image — CRITICAL: 0, HIGH: 2
View Run
```

## Test plan

- [ ] workflow_dispatch で手動実行し、Slack に件数が表示されることを確認
- [ ] 脆弱性がない場合に `CRITICAL: 0, HIGH: 0` と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)