### PR TITLE
fix(ci): backendワークフロー名からECRへの言及を削除

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -1,4 +1,4 @@
-name: CI - Backend (Trivy + ECR scan)
+name: CI - Backend (Trivy scan)
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

- ワークフロー名を `CI - Backend (Trivy + ECR scan)` → `CI - Backend (Trivy scan)` に変更
- CI は Trivy によるローカルスキャンのみで ECR を使用していないため

🤖 Generated with [Claude Code](https://claude.com/claude-code)