### PR TITLE
fix(backend): Dockerfileにapt-get upgradeを追加してOS脆弱性を解消

### DIFF
--- a/backend/sandbox-backend/Dockerfile
+++ b/backend/sandbox-backend/Dockerfile
@@ -33,8 +33,9 @@ RUN yarn build
 ########## Runtime Stage ##########
 FROM public.ecr.aws/docker/library/node:22-bookworm-slim
 
-# OpenSSL と CA を追加（サイズ削減のため後片付け）
+# OSパッケージをアップグレードし、OpenSSL と CA を追加（サイズ削減のため後片付け）
 RUN apt-get update -y \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends openssl libssl3 ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

- runtime ステージの `apt-get upgrade -y` を追加
- libgnutls30 の 5 CVE を解消
  - CVE-2026-33845 (CRITICAL): DTLS zero-length fragment DoS
  - CVE-2026-42010 (CRITICAL): NUL文字によるAuthentication Bypass
  - CVE-2026-33846 (HIGH): DTLS handshake heap buffer overflow DoS
  - CVE-2026-3833 (HIGH): nameConstraints policy bypass
  - CVE-2026-42009 (HIGH): DTLS packet reordering DoS

## Note

picomatch CVE (CVE-2026-33671) について: yarn.lock はすでに 4.0.4 に更新済みで、picomatch を使用しているのは devDependencies のみ。今回の Dockerfile 再ビルドで消えるか確認中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)