### PR TITLE
fix(frontend): Node.js 23.1 → 22.15.0 (eslint-visitor-keys@5 互換性修正)

### DIFF
--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 23.1
+          node-version: 22.15.0
 
       - name: Azure Login
         uses: azure/login@v2

--- a/docs/iac-spec.md
+++ b/docs/iac-spec.md
@@ -473,7 +473,7 @@ App Service 再起動
 ```
 Checkout
   ▼
-Node.js 23.1 セットアップ
+Node.js 22.15.0 セットアップ
   ▼
 Azure Login (OIDC)
   ▼

--- a/iac/aws/code-pipeline-frontend.tf
+++ b/iac/aws/code-pipeline-frontend.tf
@@ -138,7 +138,7 @@ resource "aws_codebuild_project" "frontend" {
                   commands:
                      - npm -v
                      - node -v
-                     - n 23.1.0
+                     - n 22.15.0
                      - node -v
                      - npm install -g yarn
                      - yarn --version


### PR DESCRIPTION
## 問題

CodePipeline フロントエンドビルドが以下のエラーで失敗していた。

```
error eslint-visitor-keys@5.0.1: The engine "node" is incompatible with this module.
Expected version "^20.19.0 || ^22.13.0 || >=24". Got "23.1.0"
```

Node.js 23.x は `eslint-visitor-keys@5.0.1` の engines 要件（`^20.19.0 || ^22.13.0 || >=24`）を満たさない。

## 修正

Node.js を 23.1.0 → **22.15.0**（Node 22 LTS）に変更。

| ファイル | 変更箇所 |
|---|---|
| `iac/aws/code-pipeline-frontend.tf` | buildspec の `n 23.1.0` → `n 22.15.0` |
| `.github/workflows/deploy-frontend.yaml` | `node-version: 23.1` → `node-version: 22.15.0` |
| `docs/iac-spec.md` | ドキュメントのバージョン表記を更新 |

## Test plan

- [ ] CodePipeline フロントエンドビルドが正常に完了することを確認