### PR TITLE
fix(iac/aws): SecurityGroup egress最小権限化・CodePipeline IAM ECS権限を特定リソースに限定

### DIFF
--- a/iac/aws/code-pipeline-backend.tf
+++ b/iac/aws/code-pipeline-backend.tf
@@ -223,16 +223,31 @@ resource "aws_iam_role_policy" "backend-codepipeline" {
           ]
         },
         {
+          # ListClusters / ListTaskDefinitions はAWS仕様上 Resource = * が必須
           Action = [
             "ecs:ListClusters",
             "ecs:ListTaskDefinitions",
-            "ecs:DescribeTasks",
+          ]
+          Effect   = "Allow"
+          Resource = ["*"]
+        },
+        {
+          # タスク定義の参照・登録はこのプロジェクトのファミリーのみに限定
+          Action = [
             "ecs:DescribeTaskDefinition",
             "ecs:RegisterTaskDefinition",
           ]
           Effect = "Allow"
           Resource = [
-            "*"
+            "${aws_ecs_task_definition.task_definition.arn_without_revision}:*",
+          ]
+        },
+        {
+          # タスク参照はこのクラスタのタスクのみに限定
+          Action = ["ecs:DescribeTasks"]
+          Effect = "Allow"
+          Resource = [
+            "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.self.account_id}:task/${aws_ecs_cluster.cluster.name}/*",
           ]
         },
         {

--- a/iac/aws/security-group.tf
+++ b/iac/aws/security-group.tf
@@ -7,14 +7,15 @@ resource "aws_security_group" "alb" {
   vpc_id = aws_vpc.vpc.id
 }
 
-# ALBアウトバウンド: 全外向け通信を許可(ECSへの転送等)
+# ALBアウトバウンド: ECSサービスのAPIポートのみ許可
 resource "aws_security_group_rule" "alb_out" {
-  security_group_id = aws_security_group.alb.id
-  type              = "egress"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id        = aws_security_group.alb.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = var.api-expose-port
+  to_port                  = var.api-expose-port
+  source_security_group_id = aws_security_group.ecs_service.id
+  description              = "to ECS service"
 }
 
 # ECSサービス用SG
@@ -38,14 +39,26 @@ resource "aws_security_group_rule" "ecs_service_in_alb" {
   description              = "internal ALB target group"
 }
 
-# ECSアウトバウンド: 全外向け通信を許可(NAT経由のSaaS呼び出し等)
-resource "aws_security_group_rule" "ecs_service_out" {
+# ECSアウトバウンド: HTTPS(VPCエンドポイント経由のECR/CloudWatch + NAT経由の外部SaaS)
+resource "aws_security_group_rule" "ecs_service_out_https" {
   security_group_id = aws_security_group.ecs_service.id
   type              = "egress"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
   cidr_blocks       = ["0.0.0.0/0"]
+  description       = "HTTPS to VPC endpoints and external SaaS (Auth0 etc.)"
+}
+
+# ECSアウトバウンド: AuroraへのPostgreSQL接続
+resource "aws_security_group_rule" "ecs_service_out_db" {
+  security_group_id        = aws_security_group.ecs_service.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 5432
+  to_port                  = 5432
+  source_security_group_id = aws_security_group.db.id
+  description              = "to Aurora DB"
 }
 
 # CloudFront VPC Origin専用の管理SGを参照(VPC Origin作成時にAWSが自動生成)
@@ -109,16 +122,6 @@ resource "aws_security_group_rule" "db_in_bastion" {
 }
 
 
-# DBアウトバウンド: 全外向け許可
-resource "aws_security_group_rule" "db_out" {
-  security_group_id = aws_security_group.db.id
-  type              = "egress"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
 # 踏み台EC2用SG
 resource "aws_security_group" "bastion" {
   description = "bastion"
@@ -142,14 +145,26 @@ resource "aws_security_group_rule" "bastion_in_mypc" {
   description       = "my pc"
 }
 
-# 踏み台アウトバウンド: 全外向け許可(SSMエンドポイント・DB等への通信用)
-resource "aws_security_group_rule" "bastion_out" {
+# 踏み台アウトバウンド: SSM VPCインターフェイスエンドポイントへのHTTPS
+resource "aws_security_group_rule" "bastion_out_ssm" {
   security_group_id = aws_security_group.bastion.id
   type              = "egress"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = [var.vpc_cidr_block]
+  description       = "SSM VPC endpoints"
+}
+
+# 踏み台アウトバウンド: DB接続(ポートフォワード・メンテ用)
+resource "aws_security_group_rule" "bastion_out_db" {
+  security_group_id        = aws_security_group.bastion.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 5432
+  to_port                  = 5432
+  source_security_group_id = aws_security_group.db.id
+  description              = "to Aurora DB"
 }
 
 
@@ -175,12 +190,13 @@ resource "aws_security_group_rule" "ssm_in" {
   description       = "ssm"
 }
 
-# SSMエンドポイントSGからのアウトバウンド: 全許可
+# SSMエンドポイントSGからのアウトバウンド: VPC内HTTPSのみ(エンドポイントはVPC内部で完結)
 resource "aws_security_group_rule" "ssm_out" {
   security_group_id = aws_security_group.ssm.id
   type              = "egress"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = [var.vpc_cidr_block]
+  description       = "response to VPC resources"
 }


### PR DESCRIPTION
## 変更概要

Security Group の egress ルール全開放と、CodePipeline IAM の ECS 権限過剰を修正。

## Security Group egress (security-group.tf)

| SG | 変更前 | 変更後 |
|---|---|---|
| ALB | `protocol=-1` to `0.0.0.0/0` | TCP `api-expose-port` to ECS SG のみ |
| ECS | `protocol=-1` to `0.0.0.0/0` | TCP 443 to `0.0.0.0/0` + TCP 5432 to DB SG |
| DB | `protocol=-1` to `0.0.0.0/0` | **削除**（Aurora はアウトバウンド接続を開始しない） |
| Bastion | `protocol=-1` to `0.0.0.0/0` | TCP 443 to VPC CIDR + TCP 5432 to DB SG |
| SSM endpoint | `protocol=-1` to `0.0.0.0/0` | TCP 443 to VPC CIDR のみ |

## IAM CodePipeline policy (code-pipeline-backend.tf)

| アクション | 変更前 | 変更後 |
|---|---|---|
| `ecs:RegisterTaskDefinition` | `Resource = ["*"]` | タスク定義ファミリ ARN に限定 |
| `ecs:DescribeTaskDefinition` | `Resource = ["*"]` | タスク定義ファミリ ARN に限定 |
| `ecs:DescribeTasks` | `Resource = ["*"]` | クラスタ内タスク ARN に限定 |
| `ecs:ListClusters` / `ecs:ListTaskDefinitions` | `Resource = ["*"]` | **維持**（AWS List API の仕様上 `*` 必須） |

## Test plan

- [x] `terraform plan` でリソース差分が意図通りであることを確認
- [ ] CodePipeline バックエンドが正常にデプロイできることを確認
- [ ] ECS タスクが起動し、ALB ヘルスチェックが通ることを確認
- [ ] Bastion から Session Manager で接続できることを確認