### PR TITLE
fix(iac/aws): CodePipeline ECSデプロイ監視に必要な ecs:ListTasks を追加

### DIFF
--- a/iac/aws/code-pipeline-backend.tf
+++ b/iac/aws/code-pipeline-backend.tf
@@ -223,11 +223,14 @@ resource "aws_iam_role_policy" "backend-codepipeline" {
           ]
         },
         {
-          # ListClusters / ListTaskDefinitions / RegisterTaskDefinition はAWS仕様上 Resource = * が必須
-          # RegisterTaskDefinition: 新規リビジョン登録時は ARN が未確定のため resource-level 制限不可
+          # Resource = * が必須なアクション:
+          # - ListClusters / ListTaskDefinitions: list系はリソースレベル制限不可
+          # - RegisterTaskDefinition: 新規リビジョン登録時は ARN が未確定のため resource-level 制限不可
+          # - ListTasks: CodePipelineがデプロイ監視に使用。サービス指定でも * が必要
           Action = [
             "ecs:ListClusters",
             "ecs:ListTaskDefinitions",
+            "ecs:ListTasks",
             "ecs:RegisterTaskDefinition",
           ]
           Effect   = "Allow"


### PR DESCRIPTION
## Summary

- CodePipelineのECSデプロイアクションがデプロイ完了監視に `ecs:ListTasks` を呼び出すが、IAMポリシーから漏れていた
- `Resource = *` が必要なアクションのブロックに `ecs:ListTasks` を追加
- これにより「The provided role does not have sufficient permissions to access ECS」エラーが解消される見込み

## 背景

CodePipeline ECS deploy actionが必要とする権限:
- `ecs:RegisterTaskDefinition` → `*`（PR #62/#63で対応済み）
- `ecs:ListTasks` → `*`（今回追加）
- `ecs:DescribeTaskDefinition`, `DescribeServices`, `UpdateService`, `DescribeTasks` → 特定ARN（対応済み）
- `iam:PassRole` → 特定ロールARN（対応済み）

## Test plan

- [ ] PR マージ後 `terraform apply` を実行
- [ ] CodePipeline バックエンドパイプラインを手動実行してデプロイ成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)