### PR TITLE
docs(readme): ローカル開発セットアップに .env.example のコピー手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,18 @@ User ── HTTPS ──> CloudFront (+ WAF v2) / Front Door (CDN)
 ```bash
 # Backend
 cd backend/sandbox-backend
+cp .env.example .env    # 実値を編集
 yarn install
 yarn start:dev          # http://localhost:3000
 
 # Frontend
 cd frontend/sandbox-frontend
+cp .env.example .env    # 実値を編集
 yarn install
 yarn dev                # http://localhost:5173
 ```
 
-バックエンドは `AUTH_ENABLED=false` でモック認証モードで起動できます。
+バックエンドは `.env` で `AUTH_ENABLED=false` を設定するとモック認証モードで起動できます（Auth0 不要）。
 
 ### インフラデプロイ
 


### PR DESCRIPTION
## Summary

- `.env.example` を追加した（PR #65）ことに伴い、README のローカル開発セットアップ手順を更新
- `cp .env.example .env` の手順を frontend / backend 両方に追加
- `AUTH_ENABLED=false` の説明を `.env` 経由で設定する形に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)