### PR TITLE
fix(azure): terraform apply 失敗の修正 (image プレースホルダ / Network Watcher data source)

### DIFF
--- a/iac/azure/container-apps.tf
+++ b/iac/azure/container-apps.tf
@@ -74,8 +74,12 @@ resource "azurerm_container_app" "app" {
     max_replicas = 3
 
     container {
-      name   = "backend"
-      image  = "${azurerm_container_registry.acr.login_server}/backend:latest"
+      name = "backend"
+      # 初回 apply 時点では ACR にまだ backend イメージが push されていないため、
+      # Microsoft 公式 Container Apps quickstart 画像をプレースホルダとして使用。
+      # 以降は GitHub Actions が `az containerapp update --image` で更新し、
+      # lifecycle.ignore_changes により Terraform 側からは差分扱いされない。
+      image  = "mcr.microsoft.com/k8se/quickstart:latest"
       cpu    = 0.5
       memory = "1Gi"
 

--- a/iac/azure/vnet_flow_log.tf
+++ b/iac/azure/vnet_flow_log.tf
@@ -3,12 +3,11 @@
 # - 分析用に Traffic Analytics で Log Analytics Workspace にも集約 (Athena相当のKQL分析の入口)
 
 # Network Watcher
-# 既定では Azure が NetworkWatcherRG/NetworkWatcher_<region> を自動作成するが、
-# 本テンプレートでは自前のRGに明示的に作成して構成を自己完結させる(複数併存可)
-resource "azurerm_network_watcher" "nw" {
-  name                = "${var.app-name}-${var.environment}-nw"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+# Azure は subscription × region につき 1 個までしか Network Watcher を作れないため、
+# 既定で auto-create される NetworkWatcherRG/NetworkWatcher_<region> を data source で参照する
+data "azurerm_network_watcher" "default" {
+  name                = "NetworkWatcher_${var.location}"
+  resource_group_name = "NetworkWatcherRG"
 }
 
 # VNet Flow Log (旧 NSG Flow Log の後継)
@@ -16,8 +15,8 @@ resource "azurerm_network_watcher" "nw" {
 # - retention は Storage 側のライフサイクル(storage-account-logs.tf)と二重管理しない
 resource "azurerm_network_watcher_flow_log" "vnet" {
   name                 = "${var.app-name}-${var.environment}-vnet-flow-log"
-  network_watcher_name = azurerm_network_watcher.nw.name
-  resource_group_name  = azurerm_network_watcher.nw.resource_group_name
+  network_watcher_name = data.azurerm_network_watcher.default.name
+  resource_group_name  = data.azurerm_network_watcher.default.resource_group_name
   location             = azurerm_resource_group.rg.location
 
   target_resource_id = azurerm_virtual_network.vnet.id


### PR DESCRIPTION
## Summary

PR #72 のマージ後、 `terraform apply` 実行時に発生した 2 件のエラーを修正します。

## エラー内容と修正

### 1. Container App: `MANIFEST_UNKNOWN`

```
Field 'template.containers.backend.image' is invalid with details:
'Invalid value: "sandboxdevregistry....azurecr.io/backend:latest":
GET https:: MANIFEST_UNKNOWN: manifest tagged by "latest" is not found'
```

**原因**: ACR に backend イメージがまだ push されていない初回 apply で `${ACR}/backend:latest` を指定していたため。

**修正**: Microsoft 公式 Container Apps quickstart 画像 (`mcr.microsoft.com/k8se/quickstart:latest`) をプレースホルダに使用。
GitHub Actions の `deploy-backend-azure.yaml` で `az containerapp update --image` を実行すると本物のイメージに差し替わり、`lifecycle.ignore_changes = [image]` により Terraform 側からは差分扱いされません。

### 2. Network Watcher: `NetworkWatcherCountLimitReached`

```
NetworkWatcherCountLimitReached: Cannot create more than 1 network watchers
for this subscription in this region.
```

**原因**: Azure は subscription × region につき Network Watcher を 1 個までしか作れない制約があり、 サブスクリプション既定の `NetworkWatcher_japaneast` が既に存在していた。

**修正**: 自前作成の `azurerm_network_watcher` リソースを撤廃し、 `data "azurerm_network_watcher" "default"` で既定の `NetworkWatcherRG/NetworkWatcher_japaneast` を参照する形に変更。

## 変更ファイル

- `iac/azure/container-apps.tf` — image をプレースホルダに変更 + コメント追記
- `iac/azure/vnet_flow_log.tf` — Network Watcher を resource → data source に変更

## Test plan

- [ ] `terraform validate` (済: Success)
- [ ] `terraform fmt -recursive` (済)
- [ ] `terraform apply` で Container App と VNet Flow Log が正常作成されること
- [ ] apply 完了後、 GitHub Actions `deploy-backend-azure.yaml` を実行して backend image が ACR に push され、 Container App が本物のイメージに差し替わること
- [ ] Front Door 経由でアプリが応答すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)