### PR TITLE
fix(azure): Container Apps 環境名に random suffix を付与 (削除スタック回避)

### DIFF
--- a/iac/azure/container-apps.tf
+++ b/iac/azure/container-apps.tf
@@ -25,8 +25,12 @@ resource "azurerm_role_assignment" "container_app_acr_pull" {
   principal_id         = azurerm_user_assigned_identity.container_app.principal_id
 }
 
+# 環境名に random_string suffix を付与している理由:
+# Container Apps 環境は削除に長時間 (数時間〜) かかることがあり、 削除中 (ScheduledForDelete) は
+# 同名で再作成できない。 suffix を付けておくと、 万一スタックしても他のリソース名を変えずに
+# Terraform の差し替えで新環境を作れる
 resource "azurerm_container_app_environment" "env" {
-  name                       = "${var.app-name}-${var.environment}-containerapps-env"
+  name                       = "${var.app-name}-${var.environment}-cae-${random_string.random.result}"
   location                   = azurerm_resource_group.rg.location
   resource_group_name        = azurerm_resource_group.rg.name
   log_analytics_workspace_id = azurerm_log_analytics_workspace.app_logs.id


### PR DESCRIPTION
## Summary

Container Apps 環境は VNet 統合があると **削除に数時間〜半日**かかることがあり、 削除中 (`ScheduledForDelete`) は **同名で再作成できない**。

固定名だと一度スタックすると Terraform 全体が止まる (apply できない) ため、 `random_string.random` の suffix を付与して衝突回避できるようにする。

## 発生していた状況

`terraform apply` 中に Container App 作成が `MANIFEST_UNKNOWN` で失敗 → ロールバックで環境が `ScheduledForDelete` になり、 **15 分以上経っても削除完了せず**、 同名で再作成できないため apply が進められない状態になった。

## 変更

`iac/azure/container-apps.tf`:
```hcl
# Before
name = "${var.app-name}-${var.environment}-containerapps-env"

# After
name = "${var.app-name}-${var.environment}-cae-${random_string.random.result}"
```

## 適用後の手順 (実害がある人向け)

```powershell
# 1. main 最新を取得
cd C:\develop\repos\template-spa-webapp
git checkout main
git pull origin main

# 2. ScheduledForDelete の古い環境を Terraform state から外す
cd iac\azure
terraform state rm azurerm_container_app_environment.env

# 3. apply で新環境 (別名) が作成される
terraform apply
```

旧 `sandbox-dev-containerapps-env` は Azure 側で削除完了するまで放置で OK (`ScheduledForDelete` 状態は課金されない)。

## Test plan

- [ ] `terraform validate` (済: Success)
- [ ] `terraform fmt -recursive` (済)
- [ ] `terraform state rm` 後の `terraform apply` で新環境が `sandbox-dev-cae-<random>` 名で作成されること
- [ ] Container App / 診断設定が新環境に紐付いて作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)