### PR TITLE
fix(azure): Container App の diagnostic_setting 削除 + KQL クエリ更新

### DIFF
--- a/iac/azure/container-apps.tf
+++ b/iac/azure/container-apps.tf
@@ -151,22 +151,13 @@ resource "azurerm_container_app" "app" {
   }
 }
 
-# Container App 用の診断ログ設定 (App Service の HTTP/Console/AppLogs 相当)
-# Container Apps では Console / System のログカテゴリが利用可能
-resource "azurerm_monitor_diagnostic_setting" "container_app" {
-  name                       = "${var.app-name}-${var.environment}-containerapp-diag"
-  target_resource_id         = azurerm_container_app.app.id
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.app_logs.id
-
-  enabled_log {
-    category = "ContainerAppConsoleLogs"
-  }
-
-  enabled_log {
-    category = "ContainerAppSystemLogs"
-  }
-
-  enabled_metric {
-    category = "AllMetrics"
-  }
-}
+# Container Apps のコンソール/システムログ:
+# 個別 Container App リソースには ContainerAppConsoleLogs / ContainerAppSystemLogs カテゴリを
+# 紐付けられない仕様 (環境 = managedEnvironments のみ対応)。
+# 本テンプレートでは azurerm_container_app_environment.env に log_analytics_workspace_id を
+# 設定済みのため、 環境経由で自動的に Log Analytics の
+# ContainerAppConsoleLogs_CL / ContainerAppSystemLogs_CL テーブルへログが流れる。
+# したがって Container App 単体への diagnostic_setting は不要 (重複させると二重課金)。
+#
+# メトリックは Azure Monitor の標準メトリックストアへ自動送信され、 monitor_alerts.tf の
+# azurerm_monitor_metric_alert から直接参照可能。

--- a/iac/azure/log_analytics_queries.tf
+++ b/iac/azure/log_analytics_queries.tf
@@ -69,33 +69,38 @@ resource "azurerm_log_analytics_saved_search" "frontdoor_error_paths" {
   KQL
 }
 
-# App Service HTTP ログ: 5xx エラー (直近1h)
+# Container Apps コンソールログ: ERROR レベル抽出 (直近1h)
 # AWS側 ECS ログ (athena_ecs_logs.tf) と同じ "アプリ層の異常検知" 用途
-resource "azurerm_log_analytics_saved_search" "appservice_http_5xx" {
-  name                       = "${var.app-name}-${var.environment}-appservice-http-5xx"
+# Container Apps Environment の log_analytics_workspace_id 経由で
+# 自動的に ContainerAppConsoleLogs_CL テーブルに格納される
+resource "azurerm_log_analytics_saved_search" "containerapp_console_errors" {
+  name                       = "${var.app-name}-${var.environment}-containerapp-console-errors"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.app_logs.id
-  category                   = "AppService"
-  display_name               = "App Service: 5xx エラー一覧 (直近1h)"
+  category                   = "ContainerApp"
+  display_name               = "Container App: コンソールERROR (直近1h)"
   query                      = <<-KQL
-    AppServiceHTTPLogs
+    ContainerAppConsoleLogs_CL
     | where TimeGenerated > ago(1h)
-    | where ScStatus >= 500
-    | project TimeGenerated, CsMethod, CsUriStem, ScStatus, TimeTaken, CIp
+    | where Log_s has_any ("ERROR", "Error", "error")
+    | project TimeGenerated, ContainerAppName_s, ContainerName_s, RevisionName_s, Log_s
     | order by TimeGenerated desc
   KQL
 }
 
-# App Service コンソールログ: ERROR レベル抽出 (直近1h)
-resource "azurerm_log_analytics_saved_search" "appservice_console_errors" {
-  name                       = "${var.app-name}-${var.environment}-appservice-console-errors"
+# Container Apps システムログ: リビジョン作成/起動失敗等のシステムイベント (直近24h)
+resource "azurerm_log_analytics_saved_search" "containerapp_system_events" {
+  name                       = "${var.app-name}-${var.environment}-containerapp-system-events"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.app_logs.id
-  category                   = "AppService"
-  display_name               = "App Service: コンソールERROR (直近1h)"
+  category                   = "ContainerApp"
+  display_name               = "Container App: システムイベント (直近24h)"
   query                      = <<-KQL
-    AppServiceConsoleLogs
-    | where TimeGenerated > ago(1h)
-    | where ResultDescription has_any ("ERROR", "Error", "error")
-    | project TimeGenerated, ResultDescription
+    ContainerAppSystemLogs_CL
+    | where TimeGenerated > ago(24h)
+    | project TimeGenerated, ContainerAppName_s, Reason_s, Type_s, Log_s
     | order by TimeGenerated desc
   KQL
 }
+
+# Container App / Front Door の HTTP 5xx 分析は Front Door 側の AFDAccessLogs を使用
+# (バックエンド単体の HTTP アクセスログは Container Apps 標準では出力されないため、
+# upstream の Front Door ログでカバーする。 別途 azurerm_log_analytics_saved_search.frontdoor_error_paths を参照)


### PR DESCRIPTION
## Summary

`terraform apply` 時に Container App 単体への diagnostic_setting で以下のエラーが発生:
```
Category 'ContainerAppConsoleLogs' is not supported.
```

`ContainerAppConsoleLogs` / `ContainerAppSystemLogs` は **Container Apps 環境 (managedEnvironments)** でしか有効でない仕様 (個別 Container App リソースには紐付けられない)。

## 修正方針

本テンプレートでは `azurerm_container_app_environment.env` に `log_analytics_workspace_id` を設定済みのため、 **環境経由で自動的に Log Analytics の `ContainerAppConsoleLogs_CL` / `ContainerAppSystemLogs_CL` テーブルへログが流れる**。

→ 個別 Container App への diagnostic_setting は不要 (重複させると二重課金) として削除。 メトリックは Azure Monitor 標準のメトリックストアへ自動送信されるので、 `monitor_alerts.tf` のアラートは引き続き機能する。

## 変更内容

### `iac/azure/container-apps.tf`
- `azurerm_monitor_diagnostic_setting.container_app` リソースを削除
- 削除理由を説明するコメントブロックを追加

### `iac/azure/log_analytics_queries.tf`
旧 App Service 系クエリ (もう存在しない `AppServiceHTTPLogs` / `AppServiceConsoleLogs` テーブル参照) を Container Apps 系に置換:

| 旧 | 新 |
|---|---|
| `appservice_http_5xx` (AppServiceHTTPLogs) | **削除** (Front Door 側 `frontdoor_error_paths` でカバー済み) |
| `appservice_console_errors` (AppServiceConsoleLogs) | `containerapp_console_errors` (ContainerAppConsoleLogs_CL) |
| - | **新規** `containerapp_system_events` (ContainerAppSystemLogs_CL — リビジョン起動失敗等) |

## Test plan

- [ ] `terraform validate` (済: Success)
- [ ] `terraform fmt` (済)
- [ ] `terraform apply` で Container App 作成完了まで進むこと
- [ ] apply 後、 Log Analytics ワークスペースに `ContainerAppConsoleLogs_CL` テーブルが現れて Container App のログが流れていること
- [ ] 保存済みクエリ `containerapp_console_errors` を実行して結果が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)