### PR TITLE
fix(azure): Container Apps を新サブネット (v2) + 専用 random_string に分離

### DIFF
--- a/iac/azure/container-apps.tf
+++ b/iac/azure/container-apps.tf
@@ -25,17 +25,30 @@ resource "azurerm_role_assignment" "container_app_acr_pull" {
   principal_id         = azurerm_user_assigned_identity.container_app.principal_id
 }
 
-# 環境名に random_string suffix を付与している理由:
+# 環境専用の random_string
+# Storage Account / ACR / Key Vault が共有している random_string.random とは分離している。
+# 理由: 環境が ScheduledForDelete でスタックした際、 random_string.random を taint すると
+# Storage 等の全リソース名まで巻き込んで destroy + recreate が走ってしまうため、
+# 環境名サフィックスだけ単独で再生成できるようにする
+resource "random_string" "container_apps_env" {
+  length  = 4
+  upper   = false
+  lower   = true
+  numeric = true
+  special = false
+}
+
+# 環境名に random suffix を付与している理由:
 # Container Apps 環境は削除に長時間 (数時間〜) かかることがあり、 削除中 (ScheduledForDelete) は
 # 同名で再作成できない。 suffix を付けておくと、 万一スタックしても他のリソース名を変えずに
 # Terraform の差し替えで新環境を作れる
 resource "azurerm_container_app_environment" "env" {
-  name                       = "${var.app-name}-${var.environment}-cae-${random_string.random.result}"
+  name                       = "${var.app-name}-${var.environment}-cae-${random_string.container_apps_env.result}"
   location                   = azurerm_resource_group.rg.location
   resource_group_name        = azurerm_resource_group.rg.name
   log_analytics_workspace_id = azurerm_log_analytics_workspace.app_logs.id
 
-  infrastructure_subnet_id       = azurerm_subnet.container_apps.id
+  infrastructure_subnet_id       = azurerm_subnet.container_apps_v2.id
   internal_load_balancer_enabled = false # Front Door からアクセスするため public LB
 
   workload_profile {

--- a/iac/azure/vnet.tf
+++ b/iac/azure/vnet.tf
@@ -7,15 +7,38 @@ resource "azurerm_virtual_network" "vnet" {
   ]
 }
 
-# Container Apps 環境用サブネット
-# - Workload Profiles 環境は /27 (32 IPs) 以上が必須
-# - Microsoft.App/environments に delegation
+# Container Apps 環境用サブネット (旧)
+# 注: container_apps (10.0.0.0/27) はかつて Container Apps 環境を載せていたが、
+# 環境の削除に長時間かかる (ScheduledForDelete) 状態のしがらみで、 同じサブネットで
+# 環境を作り直すと不安定になる事象を確認したため、 _v2 サブネットに移行 (下記)。
+# こちらのサブネットは Azure 側の旧環境クリーンアップ完了後に手動削除予定。
 resource "azurerm_subnet" "container_apps" {
   name                 = "${var.app-name}-${var.environment}-containerapps"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
   address_prefixes = [
     "10.0.0.0/27"
+  ]
+  delegation {
+    name = "delegation"
+    service_delegation {
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+      name = "Microsoft.App/environments"
+    }
+  }
+}
+
+# Container Apps 環境用サブネット (v2 — 現役)
+# - Workload Profiles 環境は /27 (32 IPs) 以上が必須
+# - Microsoft.App/environments に delegation
+resource "azurerm_subnet" "container_apps_v2" {
+  name                 = "${var.app-name}-${var.environment}-containerapps-v2"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes = [
+    "10.0.0.64/27"
   ]
   delegation {
     name = "delegation"


### PR DESCRIPTION
## Summary

新環境 `sandbox-dev-cae-gt2909` も `ScheduledForDelete` に入り、 かつ Container App 作成時に `ManagedEnvironmentNotProvisioned` で失敗する事象が再現。 旧サブネット (`10.0.0.0/27`) に Azure 側のしがらみが残っていると推測される。

サブネット自体を新規範囲に切って、 環境名のサフィックスも独立した random_string に分離することで、 ScheduledForDelete スタック時に Storage / ACR 等を巻き込まずに環境だけ再生成できるようにする。

## 変更内容

### `iac/azure/vnet.tf`
- 新サブネット `azurerm_subnet.container_apps_v2` (10.0.0.64/27) を追加
- 旧 `azurerm_subnet.container_apps` は当面残置 (Azure 側の旧環境片付け完了まで削除すると in-use エラーになるため)

### `iac/azure/container-apps.tf`
- 新規 `random_string.container_apps_env` (4 文字、 環境名サフィックス専用)
- `azurerm_container_app_environment.env` を v2 サブネット + 新 random_string に切替

## なぜ random_string を分離したか

`random_string.random` は Storage Account / ACR / Key Vault 等で共有しているため、 環境スタック時に `terraform taint random_string.random` すると **全リソース名が変わって destroy + recreate** が走り、 アプリ全体が消し飛ぶ。

環境名サフィックスだけ独立した random にしておけば、 環境のスタック時に環境だけ taint して再生成できる。

## 適用手順 (マージ後)

```powershell
cd C:\develop\repos\template-spa-webapp
git checkout main
git pull origin main

cd iac\azure
# ScheduledForDelete の env を state から外す (destroy 試行を回避)
terraform state rm azurerm_container_app_environment.env

terraform apply
```

新サブネット (`10.0.0.64/27`) + 新環境 (`sandbox-dev-cae-XXXX` の XXXX は新 random) が作成される。

旧サブネット `sandbox-dev-containerapps` は Azure 側で旧環境クリーンアップが完了したら、 後日 PR で削除予定。

## 今後同様にスタックした場合

```powershell
terraform taint random_string.container_apps_env
terraform state rm azurerm_container_app_environment.env
terraform apply
```

これで Storage 等の他リソース名を変えずに環境だけ作り直せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)