### PR TITLE
fix(azure+ci): セキュリティハードニング + CI マルチ環境対応

### DIFF
--- a/.github/workflows/deploy-backend-azure.yaml
+++ b/.github/workflows/deploy-backend-azure.yaml
@@ -12,49 +12,39 @@
       runs-on: ubuntu-latest
       timeout-minutes: 30
 
+      env:
+        # Key Vault network_acls 有効化に伴い、 KV 参照は廃止し repository variables を使用。
+        # 値は `terraform output github_actions_variables_json` で確認できる
+        ACR_NAME:                   ${{ vars.AZURE_ACR_NAME }}
+        IMAGE_NAME:                 ${{ vars.AZURE_BACKEND_IMAGE_NAME }}
+        BACKEND_WORKING_DIRECTORY:  ${{ vars.AZURE_BACKEND_WORKING_DIRECTORY }}
+        BACKEND_CONTAINER_APP_NAME: ${{ vars.AZURE_BACKEND_CONTAINER_APP_NAME }}
+        RESOURCE_GROUP_NAME:        ${{ vars.AZURE_RESOURCE_GROUP }}
+
       steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Get branch name
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-
       - name: Login to Azure using OIDC
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id:       ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id:       ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Set Environment Variables
-        run: |
-          KEY_VAULT_NAME=$(az keyvault list --query "[?ends_with(name, '${{ env.BRANCH_NAME }}')].name" -o tsv)
-          if [ -z "${KEY_VAULT_NAME}" ]; then
-            echo "Error: Key Vault not found for branch '${{ env.BRANCH_NAME }}'" >&2
-            exit 1
-          fi
-          echo "KEY_VAULT_NAME=${KEY_VAULT_NAME}"
-          echo "ACR-NAME=$(az keyvault secret show --name "ACR-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"  >> $GITHUB_ENV
-          echo "IMAGE-NAME=$(az keyvault secret show --name "IMAGE-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "BACKEND-WORKING-DIRECTORY=$(az keyvault secret show --name "BACKEND-WORKING-DIRECTORY" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "BACKEND-CONTAINER-APP-NAME=$(az keyvault secret show --name "BACKEND-CONTAINER-APP-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "RESOURCE-GROUP-NAME=$(az keyvault secret show --name "RESOURCE-GROUP-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-
-
       - name: Docker login to ACR
-        run: |
-          az acr login --name ${{ env.ACR-NAME }}
+        run: az acr login --name ${{ env.ACR_NAME }}
 
       - name: Build and push Docker image to ACR
         run: |
-          cd .${{ env.BACKEND-WORKING-DIRECTORY }}
+          cd .${{ env.BACKEND_WORKING_DIRECTORY }}
           docker build \
-            -t ${{ env.ACR-NAME }}.azurecr.io/${{ env.IMAGE-NAME }}:${{ github.sha }} \
-            -t ${{ env.ACR-NAME }}.azurecr.io/${{ env.IMAGE-NAME }}:latest \
+            -t ${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            -t ${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:latest \
             .
 
-          docker push ${{ env.ACR-NAME }}.azurecr.io/${{ env.IMAGE-NAME }}:${{ github.sha }}
-          docker push ${{ env.ACR-NAME }}.azurecr.io/${{ env.IMAGE-NAME }}:latest
+          docker push ${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:latest
 
       - name: Deploy to Container Apps
         # az containerapp update でイメージタグを差し替えると新しい revision が自動作成され、
@@ -62,6 +52,6 @@
         # (Container Apps が rolling 配置を行うため明示的な restart 不要)
         run: |
           az containerapp update \
-            --name ${{ env.BACKEND-CONTAINER-APP-NAME }} \
-            --resource-group ${{ env.RESOURCE-GROUP-NAME }} \
-            --image ${{ env.ACR-NAME }}.azurecr.io/${{ env.IMAGE-NAME }}:${{ github.sha }}
+            --name ${{ env.BACKEND_CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
+            --image ${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/deploy-backend-azure.yaml
+++ b/.github/workflows/deploy-backend-azure.yaml
@@ -2,6 +2,16 @@
 
   on:
     workflow_dispatch:
+      inputs:
+        environment:
+          description: 'Deploy target environment (GitHub Environments)'
+          required: true
+          default: 'dev'
+          type: choice
+          options:
+            - dev
+            - staging
+            - prod
 
   permissions:
     id-token: write
@@ -11,9 +21,13 @@
     build-and-deploy:
       runs-on: ubuntu-latest
       timeout-minutes: 30
+      # environment: GitHub Environments を指定すると、 vars/secrets が
+      # repository-level → 該当 environment-level の順で解決される。
+      # 各環境ごとに値を分けて持てる (dev: rg-sandbox-dev, prod: rg-sandbox-prod, 等)。
+      environment: ${{ inputs.environment }}
 
       env:
-        # Key Vault network_acls 有効化に伴い、 KV 参照は廃止し repository variables を使用。
+        # KV 参照は廃止し、 GitHub Environments の Variables / Secrets を使用。
         # 値は `terraform output github_actions_variables_json` で確認できる
         ACR_NAME:                   ${{ vars.AZURE_ACR_NAME }}
         IMAGE_NAME:                 ${{ vars.AZURE_BACKEND_IMAGE_NAME }}

--- a/.github/workflows/deploy-frontend-azure.yaml
+++ b/.github/workflows/deploy-frontend-azure.yaml
@@ -12,12 +12,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    env:
+      # Key Vault network_acls 有効化に伴い、 KV 参照は廃止し repository variables / secrets を使用。
+      # 値は `terraform output github_actions_variables_json` および
+      # `terraform output -json github_actions_secrets` で確認できる
+      FRONTEND_WORKING_DIRECTORY:    ${{ vars.AZURE_FRONTEND_WORKING_DIRECTORY }}
+      FRONTEND_STORAGE_ACCOUNT_NAME: ${{ vars.AZURE_FRONTEND_STORAGE_ACCOUNT_NAME }}
+      FRONTDOOR_PROFILE_NAME:        ${{ vars.AZURE_FRONTDOOR_PROFILE_NAME }}
+      FRONTDOOR_ENDPOINT_NAME:       ${{ vars.AZURE_FRONTDOOR_ENDPOINT_NAME }}
+      RESOURCE_GROUP_NAME:           ${{ vars.AZURE_RESOURCE_GROUP }}
+      # Vite ビルド時にバンドルされる値 (VITE_ prefix で client-side に露出するため
+      # 厳密には機密ではないが、 Auth0 関連は管理上 secrets として扱う)
+      VITE_AUTH0_CLIENT_ID: ${{ secrets.VITE_AUTH0_CLIENT_ID }}
+      VITE_AUTH0_DOMAIN:    ${{ secrets.VITE_AUTH0_DOMAIN }}
+      VITE_AUTH0_AUDIENCE:  ${{ secrets.VITE_AUTH0_AUDIENCE }}
+      VITE_API_BASE_URL:    ${{ vars.VITE_API_BASE_URL }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Get branch name
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -27,51 +40,33 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id:       ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id:       ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Set Environment Variables
-        run: |
-          KEY_VAULT_NAME=$(az keyvault list --query "[?ends_with(name, '${{ env.BRANCH_NAME }}')].name" -o tsv)
-          if [ -z "${KEY_VAULT_NAME}" ]; then
-            echo "Error: Key Vault not found for branch '${{ env.BRANCH_NAME }}'" >&2
-            exit 1
-          fi
-          echo "KEY_VAULT_NAME=${KEY_VAULT_NAME}"
-          echo "VITE_AUTH0_CLIENT_ID=$(az keyvault secret show --name "AUTH0-CLIENT-ID" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"  >> $GITHUB_ENV
-          echo "VITE_AUTH0_DOMAIN=$(az keyvault secret show --name "AUTH0-DOMAIN" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "VITE_AUTH0_AUDIENCE=$(az keyvault secret show --name "AUTH0-AUDIENCE" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"  >> $GITHUB_ENV
-          echo "VITE_API_BASE_URL=$(az keyvault secret show --name "API-BASE-URL" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "FRONTEND-STORAGE-ACCOUNT-NAME=$(az keyvault secret show --name "FRONTEND-STORAGE-ACCOUNT-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "FRONTEND-WORKING-DIRECTORY=$(az keyvault secret show --name "FRONTEND-WORKING-DIRECTORY" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "FRONTDOOR-ENDPOINRT-NAME=$(az keyvault secret show --name "FRONTDOOR-ENDPOINRT-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "FRONTDOOR-PROFILE-NAME=$(az keyvault secret show --name "FRONTDOOR-PROFILE-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
-          echo "RESOURCE-GROUP-NAME=$(az keyvault secret show --name "RESOURCE-GROUP-NAME" --vault-name ${KEY_VAULT_NAME} --query "value" -o tsv)"   >> $GITHUB_ENV
 
       - name: Install dependencies
         run: yarn install
-        working-directory: .${{ env.FRONTEND-WORKING-DIRECTORY }}
+        working-directory: .${{ env.FRONTEND_WORKING_DIRECTORY }}
 
       - name: Build React app
         run: yarn run build
-        working-directory: .${{ env.FRONTEND-WORKING-DIRECTORY }}
+        working-directory: .${{ env.FRONTEND_WORKING_DIRECTORY }}
 
       - name: Upload to Azure Blob Storage
         run: |
           az storage blob upload-batch \
-            --account-name ${{ env.FRONTEND-STORAGE-ACCOUNT-NAME }} \
+            --account-name ${{ env.FRONTEND_STORAGE_ACCOUNT_NAME }} \
             --auth-mode login \
             --overwrite \
             -d '$web' \
-            -s .${{ env.FRONTEND-WORKING-DIRECTORY }}/dist
+            -s .${{ env.FRONTEND_WORKING_DIRECTORY }}/dist
 
       - name: Purge Front Door Cache
         run: |
           az afd endpoint purge \
-          --resource-group ${{ env.RESOURCE-GROUP-NAME }} \
-          --profile-name ${{ env.FRONTDOOR-PROFILE-NAME }}  \
-          --endpoint-name ${{ env.FRONTDOOR-ENDPOINRT-NAME }} \
-          --content-paths '/*' \
-          --no-wait
+            --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
+            --profile-name ${{ env.FRONTDOOR_PROFILE_NAME }} \
+            --endpoint-name ${{ env.FRONTDOOR_ENDPOINT_NAME }} \
+            --content-paths '/*' \
+            --no-wait
           echo "✅ Cache purge initiated (async)"

--- a/.github/workflows/deploy-frontend-azure.yaml
+++ b/.github/workflows/deploy-frontend-azure.yaml
@@ -2,6 +2,16 @@ name: Deploy React to Azure Storage
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy target environment (GitHub Environments)'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
 
 permissions:
   id-token: write
@@ -11,9 +21,13 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # environment: GitHub Environments を指定すると、 vars/secrets が
+    # repository-level → 該当 environment-level の順で解決される。
+    # 各環境ごとに値を分けて持てる (dev: rg-sandbox-dev, prod: rg-sandbox-prod, 等)。
+    environment: ${{ inputs.environment }}
 
     env:
-      # Key Vault network_acls 有効化に伴い、 KV 参照は廃止し repository variables / secrets を使用。
+      # KV 参照は廃止し、 GitHub Environments の Variables / Secrets を使用。
       # 値は `terraform output github_actions_variables_json` および
       # `terraform output -json github_actions_secrets` で確認できる
       FRONTEND_WORKING_DIRECTORY:    ${{ vars.AZURE_FRONTEND_WORKING_DIRECTORY }}

--- a/iac/azure/bastion.tf
+++ b/iac/azure/bastion.tf
@@ -37,6 +37,13 @@ resource "azurerm_network_interface" "bastion_vm" {
   }
 }
 
+# Bastion NIC に NSG を付与
+# これが無いと NSG リソースを作っても効かず、 SSH (22) が全世界に開放されてしまう
+resource "azurerm_network_interface_security_group_association" "bastion_vm" {
+  network_interface_id      = azurerm_network_interface.bastion_vm.id
+  network_security_group_id = azurerm_network_security_group.bastion_vm.id
+}
+
 data "azurerm_key_vault" "vault" {
   name                = var.public-key-vault-name
   resource_group_name = var.public-key-vault-rg-name

--- a/iac/azure/container-apps.tf
+++ b/iac/azure/container-apps.tf
@@ -126,7 +126,7 @@ resource "azurerm_container_app" "app" {
       }
       env {
         name  = "AUTH_ENABLED"
-        value = "false"
+        value = "true"
       }
       env {
         name        = "DATABASE_URL"

--- a/iac/azure/key-vault.tf
+++ b/iac/azure/key-vault.tf
@@ -4,6 +4,24 @@ resource "azurerm_key_vault" "vault" {
   resource_group_name = azurerm_resource_group.rg.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
+
+  # ネットワーク制限:
+  # - 既定 Deny。 AAD 認証だけでなくネットワーク経路でも防御
+  # - bypass = AzureServices で Microsoft の信頼済みサービスを許可
+  #   → Container Apps が UAMI で secret を取得する経路は Azure backbone 経由のためここで通る
+  # - ip_rules で開発者 PC (local-pc-ip-addresses) と任意の追加 CIDR を許可
+  #
+  # ⚠ GitHub Actions ワークフロー (deploy-backend-azure.yaml / deploy-frontend-azure.yaml) は
+  #    `az keyvault secret show` で Key Vault を読み出すため、 GH-hosted runner の動的 IP からの
+  #    アクセスが Deny される。 対処は以下のいずれか:
+  #    (a) key-vault-additional-ip-rules に GitHub Actions の IP 範囲を追加 (api.github.com/meta)
+  #    (b) self-hosted runner を VNet 内に置く
+  #    (c) ワークフロー側で Key Vault 参照する代わりに GitHub Secrets に直接値を入れる
+  network_acls {
+    default_action = "Deny"
+    bypass         = "AzureServices"
+    ip_rules       = concat(var.local-pc-ip-addresses, var.key-vault-additional-ip-rules)
+  }
 }
 
 resource "azurerm_key_vault_secret" "auth0_domain" {

--- a/iac/azure/outputs.tf
+++ b/iac/azure/outputs.tf
@@ -1,0 +1,56 @@
+# GitHub Actions の Variables / Secrets に設定すべき値を出力する。
+# Key Vault network_acls 有効化に伴い、 ワークフローは Key Vault を直接参照せず
+# GH Actions の Variables / Secrets から値を取る方式に変更したため、 初期セットアップ用。
+#
+# 使い方:
+#   terraform output -raw github_actions_variables_json    # Variables (非機密) - 値が出る
+#   terraform output -json github_actions_secrets          # Secrets (機密) - -json 指定で値が出る
+#
+# GitHub UI から設定: Settings → Secrets and variables → Actions → New variable / New secret
+
+# 非機密値 (リソース名等) - GitHub Actions Variables (vars.XXX) として設定
+output "github_actions_variables" {
+  description = "GitHub Actions Repository Variables に設定する値 (非機密)"
+  value = {
+    AZURE_RESOURCE_GROUP                = azurerm_resource_group.rg.name
+    AZURE_ACR_NAME                      = azurerm_container_registry.acr.name
+    AZURE_BACKEND_IMAGE_NAME            = "${var.app-name}-${var.environment}-backend"
+    AZURE_BACKEND_WORKING_DIRECTORY     = "/${var.backend-src-root}"
+    AZURE_BACKEND_CONTAINER_APP_NAME    = azurerm_container_app.app.name
+    AZURE_FRONTEND_WORKING_DIRECTORY    = "/${var.frontend-src-root}"
+    AZURE_FRONTEND_STORAGE_ACCOUNT_NAME = azurerm_storage_account.web.name
+    AZURE_FRONTDOOR_PROFILE_NAME        = azurerm_cdn_frontdoor_profile.cdn.name
+    AZURE_FRONTDOOR_ENDPOINT_NAME       = azurerm_cdn_frontdoor_endpoint.cdn.name
+    VITE_API_BASE_URL                   = "https://${azurerm_cdn_frontdoor_endpoint.cdn.host_name}"
+  }
+}
+
+# gh CLI 等で一括設定したい場合に便利な JSON 表現
+output "github_actions_variables_json" {
+  description = "github_actions_variables の JSON 表現 (gh CLI スクリプト等で使用)"
+  value = jsonencode({
+    AZURE_RESOURCE_GROUP                = azurerm_resource_group.rg.name
+    AZURE_ACR_NAME                      = azurerm_container_registry.acr.name
+    AZURE_BACKEND_IMAGE_NAME            = "${var.app-name}-${var.environment}-backend"
+    AZURE_BACKEND_WORKING_DIRECTORY     = "/${var.backend-src-root}"
+    AZURE_BACKEND_CONTAINER_APP_NAME    = azurerm_container_app.app.name
+    AZURE_FRONTEND_WORKING_DIRECTORY    = "/${var.frontend-src-root}"
+    AZURE_FRONTEND_STORAGE_ACCOUNT_NAME = azurerm_storage_account.web.name
+    AZURE_FRONTDOOR_PROFILE_NAME        = azurerm_cdn_frontdoor_profile.cdn.name
+    AZURE_FRONTDOOR_ENDPOINT_NAME       = azurerm_cdn_frontdoor_endpoint.cdn.name
+    VITE_API_BASE_URL                   = "https://${azurerm_cdn_frontdoor_endpoint.cdn.host_name}"
+  })
+}
+
+# 機密値 - GitHub Actions Repository Secrets (secrets.XXX) として設定
+# AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID は OIDC 認証用で別途設定済みのため
+# ここには含めない (key-vault.tf に github-* secrets として記録されている)
+output "github_actions_secrets" {
+  description = "GitHub Actions Repository Secrets に設定する値 (機密)"
+  sensitive   = true
+  value = {
+    VITE_AUTH0_CLIENT_ID = auth0_client.app.client_id
+    VITE_AUTH0_DOMAIN    = var.auth0_domain
+    VITE_AUTH0_AUDIENCE  = "https://${azurerm_cdn_frontdoor_endpoint.cdn.host_name}"
+  }
+}

--- a/iac/azure/storage-account-logs.tf
+++ b/iac/azure/storage-account-logs.tf
@@ -28,6 +28,17 @@ resource "azurerm_storage_account" "logs" {
       permanent_delete_enabled = false
     }
   }
+
+  # ネットワーク制限:
+  # - 既定 Deny で外部からの直接アクセスをブロック
+  # - bypass で AzureServices/Logging/Metrics を許可 → Network Watcher Flow Logs と
+  #   Front Door 診断ログの書き込みはこれで通る (これらは Azure サービス経由)
+  # - 開発者からの直接参照 (Azure Portal / Storage Explorer) は ip_rules で許可
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices", "Logging", "Metrics"]
+    ip_rules       = var.local-pc-ip-addresses
+  }
 }
 
 # ログ保管コスト最適化: 30日後にCool、180日後にArchiveへ移行

--- a/iac/azure/variables.tf
+++ b/iac/azure/variables.tf
@@ -77,6 +77,12 @@ variable "local-pc-ip-addresses" {
   description = "接続元のIPアドレス"
 }
 
+variable "key-vault-additional-ip-rules" {
+  type        = list(string)
+  default     = []
+  description = "Key Vault network_acls の ip_rules に追加で許可する CIDR (GitHub Actions runner の IP 範囲等を入れる用途)"
+}
+
 variable "public-key-vault-name" {
   default = ""
 }


### PR DESCRIPTION
## Summary

セキュリティ修正と CI 構成変更を 4 件まとめた PR。

### 1. Container App の AUTH_ENABLED を true に変更 (commit 8070cfc)

HAR で `/api/protected` が未認証で 200 OK を返していた → 認証有効化。

### 2. インバウンド制御 3 件 (commit 13d1d48)

- 🚨 Bastion NSG が NIC に未バインド (SSH 22 が全世界開放) → `azurerm_network_interface_security_group_association` 追加
- ログ用 Storage Account の `network_rules` 追加 (Deny + bypass AzureServices/Logging/Metrics + ip_rules)
- Key Vault の `network_acls` 追加 (Deny + bypass AzureServices + ip_rules)

### 3. GH Actions から Key Vault 参照を撤廃 (commit a9d62f9)

KV network_acls 有効化で GH-hosted runner の動的 IP からの KV アクセスが 403 になるため、 ワークフローを GH Variables/Secrets 直接参照に変更。 + `iac/azure/outputs.tf` で設定すべき値を terraform output で取得可能に。

### 4. GitHub Environments でマルチ環境対応 (commit e669e66)

`workflow_dispatch.inputs.environment` で deploy 先環境 (`dev` / `staging` / `prod`) を選択、 `jobs.X.environment` に渡すことで vars/secrets を環境別に持てる構成に。

## マージ後のセットアップ手順

```powershell
# 1. terraform apply
cd C:\develop\repos\template-spa-webapp
git checkout main && git pull origin main
cd iac\azure
terraform apply

# 2. 設定すべき値を確認
terraform output github_actions_variables
terraform output -json github_actions_secrets
```

**3. GitHub UI で各環境を作成して値を登録**

`Settings → Environments → New environment` で `dev` / `staging` / `prod` を作成 (使うものだけで OK)。 各 Environment 内に Variables / Secrets を登録:

#### Variables (環境ごとに値を変える)
| 変数名 | 値の取得元 |
|---|---|
| `AZURE_RESOURCE_GROUP` | terraform output |
| `AZURE_ACR_NAME` | terraform output |
| `AZURE_BACKEND_IMAGE_NAME` | terraform output |
| `AZURE_BACKEND_WORKING_DIRECTORY` | terraform output |
| `AZURE_BACKEND_CONTAINER_APP_NAME` | terraform output |
| `AZURE_FRONTEND_WORKING_DIRECTORY` | terraform output |
| `AZURE_FRONTEND_STORAGE_ACCOUNT_NAME` | terraform output |
| `AZURE_FRONTDOOR_PROFILE_NAME` | terraform output |
| `AZURE_FRONTDOOR_ENDPOINT_NAME` | terraform output |
| `VITE_API_BASE_URL` | terraform output |

#### Secrets (環境ごとに値を変える)
| シークレット名 | 値の取得元 |
|---|---|
| `VITE_AUTH0_CLIENT_ID` | terraform output -json github_actions_secrets |
| `VITE_AUTH0_DOMAIN` | 同上 |
| `VITE_AUTH0_AUDIENCE` | 同上 |

#### Repository Secrets (全環境共通、 既存)
`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` は OIDC 用で全環境共通の場合は Repository secrets のままで OK。 環境ごとに違う Service Principal を使う場合は Environment Secrets として上書き設定。

**4. ワークフロー実行**

`Actions → Build and Deploy to Azure Container Apps → Run workflow` → Environment 選択 → 実行

## ⚠ Required reviewers 等の保護ルール (任意・推奨)

GitHub Environment の Settings から prod 環境に以下を付与すると安全:

- **Required reviewers**: prod デプロイ実行に承認を必須化
- **Deployment branches**: prod デプロイは `main` ブランチのみ許可
- **Wait timer**: デプロイ完了後の冷却期間

## 含まれるコミット

| commit | 内容 |
|---|---|
| `8070cfc` | `AUTH_ENABLED = "true"` |
| `13d1d48` | Bastion NSG / KV network_acls / ログ SA network_rules |
| `a9d62f9` | GH Actions を KV 参照から GH Variables/Secrets 直接参照に変更 + outputs.tf |
| `e669e66` | GH Environments マルチ環境対応 (inputs.environment + jobs.X.environment) |

## Test plan

- [ ] `terraform validate` (済: Success)
- [ ] `terraform fmt` (済)
- [ ] apply 後、 Bastion VM への SSH が許可 IP 以外から不可
- [ ] apply 後、 `GET /api/protected` (トークン無し) で 401
- [ ] apply 後、 Container App が DATABASE-URL を取得できる
- [ ] GH Environment `dev` に Variables/Secrets を設定後、 `deploy-backend-azure.yaml` 実行 (environment=dev) で Container App が更新できる
- [ ] `deploy-frontend-azure.yaml` 実行 (environment=dev) でフロントエンドがビルド・アップロードできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)