### PR TITLE
fix(azure): Storage / Key Vault の ip_rules から /32 を剥がす

### DIFF
--- a/iac/azure/key-vault.tf
+++ b/iac/azure/key-vault.tf
@@ -17,10 +17,15 @@ resource "azurerm_key_vault" "vault" {
   #    (a) key-vault-additional-ip-rules に GitHub Actions の IP 範囲を追加 (api.github.com/meta)
   #    (b) self-hosted runner を VNet 内に置く
   #    (c) ワークフロー側で Key Vault 参照する代わりに GitHub Secrets に直接値を入れる
+  # ⚠ Key Vault の ip_rules も /31 /32 を受け付けず、 単一 IP は マスク無し で渡す必要がある
+  #   (Storage Account と同じ制約。 NSG とはここが違う)
   network_acls {
     default_action = "Deny"
     bypass         = "AzureServices"
-    ip_rules       = concat(var.local-pc-ip-addresses, var.key-vault-additional-ip-rules)
+    ip_rules = [
+      for ip in concat(var.local-pc-ip-addresses, var.key-vault-additional-ip-rules) :
+      trimsuffix(ip, "/32")
+    ]
   }
 }
 

--- a/iac/azure/storage-account-logs.tf
+++ b/iac/azure/storage-account-logs.tf
@@ -34,10 +34,13 @@ resource "azurerm_storage_account" "logs" {
   # - bypass で AzureServices/Logging/Metrics を許可 → Network Watcher Flow Logs と
   #   Front Door 診断ログの書き込みはこれで通る (これらは Azure サービス経由)
   # - 開発者からの直接参照 (Azure Portal / Storage Explorer) は ip_rules で許可
+  #
+  # ⚠ Storage Account の ip_rules は /31 /32 を受け付けず、 単一 IP は マスク無し で渡す必要がある
+  #   (NSG の source_address_prefixes は /32 込みで OK なので、 ここで trimsuffix で剥がす)
   network_rules {
     default_action = "Deny"
     bypass         = ["AzureServices", "Logging", "Metrics"]
-    ip_rules       = var.local-pc-ip-addresses
+    ip_rules       = [for ip in var.local-pc-ip-addresses : trimsuffix(ip, "/32")]
   }
 }
 


### PR DESCRIPTION
## Summary

PR #77 マージ後に `terraform apply` で発生したエラーへの追従修正。

```
Error: "network_rules.0.ip_rules.0" must start with IPV4 address and/or slash,
number of bits (0-30) as prefix. Example: 23.45.1.0/30 but got "116.220.70.205/32"
```

## 原因

Azure の制約として:
- **Storage Account** `network_rules.ip_rules` / **Key Vault** `network_acls.ip_rules` は `/31` `/32` を受け付けず、 単一 IP は **マスク無し** で渡す必要がある
- **NSG** `security_rule.source_address_prefixes` は `/32` 込みで OK

同じ `var.local-pc-ip-addresses` を NSG / Storage / Key Vault で流用する設計上、 値に `/32` が付いていると Storage と Key Vault 側で 400 になる。

## 修正

`trimsuffix(ip, "/32")` で `/32` だけストリップして渡すよう変更:

```hcl
# Storage Account (storage-account-logs.tf)
- ip_rules = var.local-pc-ip-addresses
+ ip_rules = [for ip in var.local-pc-ip-addresses : trimsuffix(ip, "/32")]

# Key Vault (key-vault.tf)
- ip_rules = concat(var.local-pc-ip-addresses, var.key-vault-additional-ip-rules)
+ ip_rules = [
+   for ip in concat(var.local-pc-ip-addresses, var.key-vault-additional-ip-rules) :
+   trimsuffix(ip, "/32")
+ ]
```

- `116.220.70.205/32` → `116.220.70.205` (Azure は単一 IP と解釈)
- `1.2.3.0/24` → `1.2.3.0/24` (素通り)
- NSG 側は素の `var.local-pc-ip-addresses` を使うので `/32` 込みで OK

## Test plan

- [ ] `terraform validate` (済: Success)
- [ ] `terraform fmt` (済)
- [ ] `terraform apply` で Storage Account / Key Vault の network 制限が想定通り適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)