### PR TITLE
fix(azure): Container App の DATABASE-URL を CA secret store に移行 (KV 参照撤廃)

### DIFF
--- a/iac/azure/container-apps.tf
+++ b/iac/azure/container-apps.tf
@@ -80,10 +80,22 @@ resource "azurerm_container_app" "app" {
     identity = azurerm_user_assigned_identity.container_app.id
   }
 
+  # DATABASE-URL は Container Apps 内蔵の secret store に直接格納する。
+  #
+  # 当初は Key Vault 参照 (key_vault_secret_id) を使っていたが、 KV の network_acls を
+  # 有効化すると Container Apps platform からの secret fetch がブロックされる。
+  # Microsoft ドキュメントは環境の static_ip_address を ip_rules に追加することで解決
+  # するとあるが、 実際には CA platform は VNet egress 外の Microsoft 内部経路で fetch
+  # するため allowlist が効かないケースがある。
+  #
+  # 対処として:
+  # - DATABASE-URL は Container Apps secret store に直接埋め込む (azure_database.tf の
+  #   local.database_url を流用)
+  # - KV の DATABASE-URL secret 自体は残置 (key-vault.tf 参照) — 他の用途のために。
+  # - KV network_acls はそのまま維持され、 他の secret (auth0 等) の保護は継続する
   secret {
-    name                = "database-url"
-    key_vault_secret_id = azurerm_key_vault_secret.postgre_flexible_server_connection_string.versionless_id
-    identity            = azurerm_user_assigned_identity.container_app.id
+    name  = "database-url"
+    value = local.database_url
   }
 
   template {
@@ -150,9 +162,9 @@ resource "azurerm_container_app" "app" {
     }
   }
 
-  # KV Access / ACR Pull 権限が先に確立してから Container App を作るための明示的依存
+  # ACR Pull 権限が先に確立してから Container App を作るための明示的依存
+  # (KV Access Policy は不要になった — secret は KV ではなく CA secret store 経由)
   depends_on = [
-    azurerm_key_vault_access_policy.container_app_identity,
     azurerm_role_assignment.container_app_acr_pull,
   ]
 

--- a/iac/azure/key-vault.tf
+++ b/iac/azure/key-vault.tf
@@ -19,11 +19,20 @@ resource "azurerm_key_vault" "vault" {
   #    (c) ワークフロー側で Key Vault 参照する代わりに GitHub Secrets に直接値を入れる
   # ⚠ Key Vault の ip_rules も /31 /32 を受け付けず、 単一 IP は マスク無し で渡す必要がある
   #   (Storage Account と同じ制約。 NSG とはここが違う)
+  #
+  # ⚠ bypass = "AzureServices" は Container Apps の secret 取得には効かない:
+  #   Key Vault の "trusted services" 一覧に Container Apps が含まれておらず、
+  #   UAMI 経由の secret fetch は通常のネットワーク経路で Deny される。
+  #   → Container Apps 環境の outbound 固定 IP (static_ip_address) を ip_rules に明示追加する
   network_acls {
     default_action = "Deny"
     bypass         = "AzureServices"
     ip_rules = [
-      for ip in concat(var.local-pc-ip-addresses, var.key-vault-additional-ip-rules) :
+      for ip in concat(
+        var.local-pc-ip-addresses,
+        var.key-vault-additional-ip-rules,
+        [azurerm_container_app_environment.env.static_ip_address],
+      ) :
       trimsuffix(ip, "/32")
     ]
   }

--- a/iac/azure/key-vault.tf
+++ b/iac/azure/key-vault.tf
@@ -20,19 +20,16 @@ resource "azurerm_key_vault" "vault" {
   # ⚠ Key Vault の ip_rules も /31 /32 を受け付けず、 単一 IP は マスク無し で渡す必要がある
   #   (Storage Account と同じ制約。 NSG とはここが違う)
   #
-  # ⚠ bypass = "AzureServices" は Container Apps の secret 取得には効かない:
-  #   Key Vault の "trusted services" 一覧に Container Apps が含まれておらず、
-  #   UAMI 経由の secret fetch は通常のネットワーク経路で Deny される。
-  #   → Container Apps 環境の outbound 固定 IP (static_ip_address) を ip_rules に明示追加する
+  # 補足: 過去に Container Apps の secret 取得を通すため env の static_ip_address を
+  # 追加する案を試したが、 CA platform が VNet egress 外の Microsoft 内部経路で fetch する
+  # 動作のため allowlist が効かなかった。
+  # 現在は Container App 側で KV を参照せず CA secret store に値を直接持たせる構成にしたため、
+  # ここでは local PC + 任意の追加 IP のみで OK。
   network_acls {
     default_action = "Deny"
     bypass         = "AzureServices"
     ip_rules = [
-      for ip in concat(
-        var.local-pc-ip-addresses,
-        var.key-vault-additional-ip-rules,
-        [azurerm_container_app_environment.env.static_ip_address],
-      ) :
+      for ip in concat(var.local-pc-ip-addresses, var.key-vault-additional-ip-rules) :
       trimsuffix(ip, "/32")
     ]
   }


### PR DESCRIPTION
## Summary

`terraform apply` で Container App 作成時に発生する以下のエラーを解消する。

```
Failed to provision revision for container app 'sandbox-dev-app'.
Field 'configuration.secrets' is invalid: 'Invalid value: "database-url":
unable to fetch secret 'database-url' using Managed identity'';..
```

## 原因と当初アプローチの限界

Key Vault `network_acls` を Deny にすると Container App platform からの secret fetch がブロックされる。

当初 (commit 31b8ecc): **Container Apps 環境の outbound IP (`static_ip_address`) を KV ip_rules に追加する**方針を試みた。 Microsoft Learn のドキュメント通りの設定だったが、 **実際には機能しなかった** (Container Apps platform は VNet egress 外の Microsoft 内部経路で KV を叩いているようで、 env の static_ip_address からの通信にならない)。

## 採用した方針: CA secret store に直接埋め込む

Container App の DATABASE-URL secret を Key Vault 参照ではなく Container Apps 内蔵の secret store に直接持たせる:

```hcl
# Before
secret {
  name                = "database-url"
  key_vault_secret_id = azurerm_key_vault_secret.postgre_flexible_server_connection_string.versionless_id
  identity            = azurerm_user_assigned_identity.container_app.id
}

# After
secret {
  name  = "database-url"
  value = local.database_url    # azure_database.tf の locals 経由
}
```

これにより:
- ✅ Container App の起動が KV へのネットワーク到達に依存しなくなる
- ✅ KV `network_acls` を Deny のまま維持できる (他の secret の保護は継続)
- ✅ env の static_ip_address を KV ip_rules に入れる workaround も不要になる
- ⚠ DATABASE-URL の値が Terraform state に保存される
  - state ファイル自体のアクセス制御で対処
  - production では KV Private Endpoint + Secret Store CSI Driver 等への移行を検討

## 変更内容

### `iac/azure/container-apps.tf`
- `secret` ブロックを `key_vault_secret_id` 参照から `value = local.database_url` 直接埋め込みに変更
- `depends_on` から `azurerm_key_vault_access_policy.container_app_identity` を除去 (KV 参照しなくなったため)

### `iac/azure/key-vault.tf`
- `network_acls.ip_rules` から `azurerm_container_app_environment.env.static_ip_address` を除去 (機能していなかったため)

### 残置するもの (将来の参照可能性のため)
- `azurerm_key_vault_secret.postgre_flexible_server_connection_string` (KV 内の DATABASE-URL secret)
- `azurerm_key_vault_access_policy.container_app_identity` (UAMI 向け KV アクセス権)

## 含まれるコミット

| commit | 内容 |
|---|---|
| `31b8ecc` | (初手・失敗) env.static_ip_address を KV ip_rules に追加 |
| `df0fad0` | DATABASE-URL を CA secret store に移行 + 失敗策の撤回 |

## Test plan

- [x] `terraform validate` (Success)
- [x] `terraform fmt`
- [ ] `terraform apply` で Container App が DATABASE-URL を取得して起動完了すること
- [ ] アプリから DB に接続できること (Front Door 経由 `/api/protected` 等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)