### PR TITLE
fix(azure): Federated Identity の subject を GitHub Environment 'main' に統一

### DIFF
--- a/.github/workflows/deploy-backend-azure.yaml
+++ b/.github/workflows/deploy-backend-azure.yaml
@@ -6,12 +6,13 @@
         environment:
           description: 'Deploy target environment (GitHub Environments)'
           required: true
-          default: 'dev'
+          default: 'main'
           type: choice
           options:
-            - dev
-            - staging
-            - prod
+            - main
+          # 別環境を増やす場合: ここに staging / prod 等を追加し、
+          # iac/azure 側でも azuread_application_federated_identity_credential を
+          # 該当 environment 名で追加 (subject = "repo:OWNER/REPO:environment:<name>")
 
   permissions:
     id-token: write

--- a/.github/workflows/deploy-frontend-azure.yaml
+++ b/.github/workflows/deploy-frontend-azure.yaml
@@ -6,12 +6,13 @@ on:
       environment:
         description: 'Deploy target environment (GitHub Environments)'
         required: true
-        default: 'dev'
+        default: 'main'
         type: choice
         options:
-          - dev
-          - staging
-          - prod
+          - main
+        # 別環境を増やす場合: ここに staging / prod 等を追加し、
+        # iac/azure 側でも azuread_application_federated_identity_credential を
+        # 該当 environment 名で追加 (subject = "repo:OWNER/REPO:environment:<name>")
 
 permissions:
   id-token: write

--- a/iac/azure/service-principal.tf
+++ b/iac/azure/service-principal.tf
@@ -38,10 +38,15 @@ resource "azurerm_role_assignment" "github_actions_cdn_profile_contributor" {
 resource "azuread_application_federated_identity_credential" "github_actions" {
   application_id = azuread_application_registration.github_actions.id
   display_name   = "${var.app-name}-${var.environment}-github-actions-${var.target-branch}"
-  description    = "Deployments for ${var.github-repository-name} ${var.target-branch}"
+  description    = "Deployments for ${var.github-repository-name} via GitHub Environment '${var.target-branch}'"
   audiences      = ["api://AzureADTokenExchange"]
   issuer         = "https://token.actions.githubusercontent.com"
-  subject        = "repo:${var.github-repository-name}:ref:refs/heads/${var.target-branch}"
+  # GitHub Actions の job に environment: ${{ inputs.environment }} を指定すると、
+  # OIDC token の subject claim が `repo:OWNER/REPO:environment:ENV_NAME` 形式になる。
+  # 本テンプレートでは main ブランチ用の env 1 つだけを用意する方針なので、
+  # var.target-branch (= "main") を環境名として使用する。
+  # 別環境を追加する場合は azuread_application_federated_identity_credential を for_each 等で増やす。
+  subject = "repo:${var.github-repository-name}:environment:${var.target-branch}"
 }
 
 resource "azurerm_role_assignment" "github_actions_acr_push" {


### PR DESCRIPTION
## Summary

GH Actions の OIDC ログインで発生していたエラーを修正:

```
AADSTS700213: No matching federated identity record found for presented assertion
subject 'repo:extra-fe/template-spa-webapp:environment:dev'.
```

## 原因

GitHub Actions の job に `environment: ${{ inputs.environment }}` を指定すると、 **OIDC token の subject claim が `repo:OWNER/REPO:environment:ENV_NAME` 形式になる**。

ところが既存の Federated Identity Credential ([service-principal.tf](iac/azure/service-principal.tf)) の subject は `:ref:refs/heads/main` 形式のままで、 一致せず認証失敗。

## 修正

テンプレートとして main ブランチ用の env 1 つだけを用意する方針なので、 単純にクレデンシャルの subject を `:environment:main` 形式に変更:

```hcl
# Before
subject = "repo:${var.github-repository-name}:ref:refs/heads/${var.target-branch}"

# After
subject = "repo:${var.github-repository-name}:environment:${var.target-branch}"
```

`var.target-branch` の既定値は `"main"` のまま据置。

合わせて workflows の `inputs.environment` choices も整理 (dev/staging/prod → main のみ、 デフォルト main)。

## 別環境を追加する場合の手順 (将来用)

将来 `staging` や `prod` を追加するときは:

1. `iac/azure/service-principal.tf` で federated credential を for_each 等で複数化:
   ```hcl
   resource "azuread_application_federated_identity_credential" "github_actions_extra" {
     for_each       = toset(["staging", "prod"])
     application_id = azuread_application_registration.github_actions.id
     subject        = "repo:${var.github-repository-name}:environment:${each.key}"
     ...
   }
   ```

2. `deploy-*-azure.yaml` の `inputs.environment.options` に `staging` / `prod` を追加

3. GitHub UI で対応する Environment を作成 + Variables/Secrets 登録

## 変更ファイル

- `iac/azure/service-principal.tf` — subject を環境ベースに
- `.github/workflows/deploy-backend-azure.yaml` — choices = [main]
- `.github/workflows/deploy-frontend-azure.yaml` — choices = [main]

## マージ後の手順

```powershell
# 1. apply で Federated Credential 更新
cd C:\develop\repos\template-spa-webapp
git checkout main && git pull origin main
cd iac\azure
terraform apply

# 2. GitHub UI で `main` Environment を作成
#    Settings → Environments → New environment → "main"

# 3. 同 Environment に Variables / Secrets を登録
#    (`terraform output` の値を貼り付け)

# 4. ワークフロー実行
gh workflow run deploy-frontend-azure.yaml --ref main --field environment=main
gh workflow run deploy-backend-azure.yaml --ref main --field environment=main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)