### PR TITLE
fix(azure): Container Apps Env の不要な毎回再作成を防ぐ

### DIFF
--- a/iac/azure/container-apps.tf
+++ b/iac/azure/container-apps.tf
@@ -55,6 +55,20 @@ resource "azurerm_container_app_environment" "env" {
     name                  = "Consumption"
     workload_profile_type = "Consumption"
   }
+
+  # azurerm provider の Container Apps Env (Workload Profiles + VNet) の既知挙動への対策:
+  # - infrastructure_resource_group_name: Azure が裏で自動生成する
+  #   ME_<env>_<rg>_<region> 形式の "インフラ用 RG" (内部の LB/NSG 等を入れる)。
+  #   config 未指定だと state の値との diff が "forces replacement" を引き起こす。
+  # - workload_profile: Consumption type では Azure が maximum_count/minimum_count を 0 に
+  #   デフォルト設定するが、 config 未指定だと state との diff になる。
+  # → 両方とも Azure 任せでよい属性なので ignore_changes で無視 (毎回 env 再作成を回避)
+  lifecycle {
+    ignore_changes = [
+      infrastructure_resource_group_name,
+      workload_profile,
+    ]
+  }
 }
 
 # Container App 本体


### PR DESCRIPTION
## Summary

`terraform plan` で **何もしていないのに `azurerm_container_app_environment.env` が毎回 destroy and recreate (= replaced)** になっていた問題を修正する。

実害として、 image / env vars 変更等の本来「リビジョン追加 (数秒)」で済む変更でも、 env 再作成に巻き込まれて 1 回の apply に 3〜5 分以上かかっていた。

## 原因

Container Apps の **Workload Profiles + VNet 統合** 構成では、 Azure が裏で以下を自動設定する:

1. **`infrastructure_resource_group_name`**
   `ME_<env名>_<RG名>_<region>` 形式で「インフラ用 RG」を自動生成
   (内部の LB / NSG / その他 Azure 内部リソースが入る)
2. **`workload_profile.maximum_count` / `minimum_count`**
   Consumption type ではどちらも `0` にデフォルト設定

azurerm provider はこれらを state に記録するが、 .tf 上では指定していないため:
- state: 値あり (Azure が設定したもの)
- config: 未指定 (= null)
- 差分: `forces replacement`

実際の plan 出力 (抜粋):
```
- infrastructure_resource_group_name = "ME_sandbox-dev-cae-4m89_rg-sandbox-dev_japaneast" -> null # forces replacement
- workload_profile {
    - maximum_count         = 0 -> null
    - minimum_count         = 0 -> null
  ...
```

## 修正

`lifecycle.ignore_changes` で Azure 自動設定値を尊重するよう変更:

```hcl
resource "azurerm_container_app_environment" "env" {
  ...
  workload_profile {
    name                  = "Consumption"
    workload_profile_type = "Consumption"
  }

  lifecycle {
    ignore_changes = [
      infrastructure_resource_group_name,
      workload_profile,
    ]
  }
}
```

両者とも Azure 任せで問題ない属性 (我々のテンプレでは触らない)。

## 期待される効果

- `terraform plan` で env の変更が出なくなる (image 等の更新では Container App だけが対象)
- `terraform apply` が数秒で完了 (Container App 側はリビジョン追加で即終わる)
- env を意図的に作り直したい場合は `terraform taint random_string.container_apps_env` で名前再生成 → env 自然 recreate

## Test plan

- [x] `terraform validate` (Success)
- [x] `terraform fmt`
- [ ] `terraform apply` で env の再作成が走らず、 数秒で完了すること
- [ ] その後の `terraform plan` で `No changes` が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)