### PR TITLE
feat(gcp): AWS パリティの GCP インフラ (Cloud Run / Cloud SQL / Cloud Build + Deploy)

### DIFF
--- a/docs/iac-spec.md
+++ b/docs/iac-spec.md
@@ -2,14 +2,14 @@
 
 ## 1. 概要
 
-AWS と Azure の両クラウドに同一アプリケーションをデプロイするためのインフラ定義。Terraformで全リソースを管理し、CI/CDパイプラインによる自動デプロイを実現する。
+AWS、Azure、GCP の 3 クラウドに同一アプリケーションをデプロイするためのインフラ定義。Terraformで全リソースを管理し、CI/CDパイプラインによる自動デプロイを実現する。
 
 | 項目 | 値 |
 |---|---|
 | IaCツール | Terraform 1.13.5 |
-| 対象クラウド | AWS, Azure |
-| 認証基盤 | Auth0（両クラウド共通） |
-| ソースパス | `iac/aws/`, `iac/azure/` |
+| 対象クラウド | AWS, Azure, GCP |
+| 認証基盤 | Auth0（3クラウド共通） |
+| ソースパス | `iac/aws/`, `iac/azure/`, `iac/gcp/` |
 
 ## 2. アーキテクチャ概要
 
@@ -30,14 +30,14 @@ AWS と Azure の両クラウドに同一アプリケーションをデプロイ
 ユーザー
   │
   ▼
-CloudFront (+ WAF v2) / Front Door (CDN)
+CloudFront (+ WAF v2) / Front Door / External Application LB (+ Cloud Armor)
   │
-  ├── /* ──────────> S3 / Storage Account (Frontend - React SPA)
+  ├── /* ──────────> S3 / Storage Account / Cloud Storage (Frontend - React SPA)
   │
-  └── /api/* ──────> ALB + ECS Fargate / App Service (Backend - NestJS)
+  └── /api/* ──────> ALB + ECS Fargate / App Service / Cloud Run (Backend - NestJS)
                          │
                          ▼
-                     Aurora Serverless / PostgreSQL Flexible Server (DB)
+                     Aurora Serverless / PostgreSQL Flexible Server / Cloud SQL for PostgreSQL (DB)
 ```
 
 ---
@@ -501,7 +501,246 @@ Front Door キャッシュパージ
 
 ---
 
-## 5. GitHub Actions CI (セキュリティスキャン)
+## 5. GCP インフラストラクチャ
+
+### 5.1 Terraform ファイル構成
+
+| ファイル | 管理リソース |
+|---|---|
+| `provider.tf` | Google Cloud, google-beta, Auth0 プロバイダ設定 |
+| `variables.tf` | 入力変数定義 / 公開URL local |
+| `vpc.tf` | VPC ネットワーク, サブネット, Cloud NAT, Serverless VPC Access コネクタ, Private Service Access |
+| `firewall.tf` | VPC Firewall ルール (IAP / Bastion / DB) |
+| `cloud_storage.tf` | フロントエンド用 Cloud Storage バケット |
+| `load_balancer.tf` | External Application LB + Cloud CDN + URL マップ + Serverless NEG |
+| `cloud_armor.tf` | Cloud Armor セキュリティポリシー (WAF 相当) |
+| `artifact_registry.tf` | バックエンド用 Artifact Registry |
+| `cloud_run.tf` | Cloud Run サービス + ランタイム SA + IAM |
+| `cloud_sql.tf` | Cloud SQL for PostgreSQL (Private IP) + DB / ユーザ |
+| `secret_manager.tf` | DATABASE_URL を格納する Secret Manager シークレット |
+| `bastion.tf` | Compute Engine Bastion VM (IAP TCP forwarding 経由) |
+| `auth0.tf` | Auth0 SPA クライアント・リソースサーバー |
+| `cloud_build_backend.tf` | バックエンド CI/CD (Cloud Build → AR → Cloud Deploy → Cloud Run) |
+| `cloud_build_frontend.tf` | フロントエンド CI/CD (Cloud Build → GCS sync → Cloud CDN invalidate) |
+| `monitoring_alerts.tf` | Cloud Monitoring アラートポリシー + Pub/Sub 通知チャネル |
+| `start-stop-resources.tf` | 自動起動・停止 (Cloud Scheduler + Cloud Workflows) |
+| `bigquery_log_sinks.tf` | Cloud Logging → BigQuery sink (LB / Cloud Run / Cloud Armor / VPC Flow Logs) |
+
+### 5.2 ネットワーク
+
+**VPC 構成:**
+
+| リソース | 変数名 | デフォルト値 | リージョン |
+|---|---|---|---|
+| VPC | (auto subnet 無効) | — | グローバル |
+| プライマリサブネット | `subnet_primary_cidr_block` | `172.16.2.0/24` | asia-northeast1 |
+| Serverless VPC コネクタサブネット | `subnet_connector_cidr_block` | `172.16.4.0/28` (`/28` 必須) | asia-northeast1 |
+| Private Service Access レンジ | `psa_range_cidr_block` | `172.16.16.0/20` | グローバル予約 |
+
+**Cloud NAT (Cloud Router):** AWS の Regional NAT Gateway / Azure の VNet egress 相当。Bastion 等 VPC 内インスタンスのアウトバウンドインターネット通信を NAT。
+
+**Private Google Access:** プライマリサブネットで有効化。AWS の VPCエンドポイント (Interface) 相当。NAT 経由せず Google API (Artifact Registry / Secret Manager / Cloud Logging 等) にプライベートアクセス。
+
+**Serverless VPC Access コネクタ:** Cloud Run → VPC 内の Cloud SQL Private IP に到達するための論理経路。AWS の ECS awsvpc モード相当。
+
+**Private Service Access:** Service Networking ピアリングを介して Cloud SQL の Private IP を VPC 内ネットワークに公開。
+
+### 5.3 フロントエンド (Cloud Storage + LB + Cloud CDN)
+
+| リソース | 設定 |
+|---|---|
+| Cloud Storage バケット | uniform_bucket_level_access + public_access_prevention=enforced |
+| SPA ルーティング | `notFoundPage = "index.html"` (AWS の `403 → /index.html` 相当) |
+| Backend Bucket (Cloud CDN) | `cache_mode = USE_ORIGIN_HEADERS` で `index.html` の `no-store, no-cache` を尊重 |
+| LB | External Application LB (EXTERNAL_MANAGED) |
+| HTTPS 証明書 | Google Managed SSL Certificate (`lb-domain` 設定時のみ作成) |
+
+**URL マップ:**
+
+| 優先度 | パス | ターゲット | 備考 |
+|---|---|---|---|
+| デフォルト | `*` | Backend Bucket (GCS) | Cloud CDN 経由で静的アセット配信 |
+| 1 | `/api/*` | Backend Service → Serverless NEG → Cloud Run | CDN なし、Cloud Armor 適用 |
+
+**セキュリティヘッダ:** URL マップの `header_action` で HSTS / X-Content-Type-Options / X-Frame-Options / Referrer-Policy / X-XSS-Protection / Permissions-Policy / CSP を一括付与 (AWS の Response Headers Policy 相当)。
+
+### 5.4 バックエンド (Cloud Run)
+
+| 項目 | 値 |
+|---|---|
+| 実行環境 | Cloud Run v2 (フルマネージドサーバーレス) |
+| CPU | 1 vCPU (cpu_idle 有効) |
+| メモリ | 512 MiB |
+| コンテナポート | 3000 (`api-expose-port` 変数) |
+| イメージ | Artifact Registry (`backend:latest` / `backend:$SHORT_SHA`) |
+| Ingress | `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` (LB 経由のみ受信) |
+| VPC アクセス | Serverless VPC Access コネクタ (egress = PRIVATE_RANGES_ONLY) |
+| ヘルスチェック | startup_probe / liveness_probe = `GET /health` |
+| ログ | Cloud Logging (Cloud Run 標準出力) → BigQuery sink で分析 |
+| シークレット | DATABASE_URL = Secret Manager `secret_key_ref` |
+| ランタイム SA | `${app-name}-${environment}-run` (artifactregistry.reader / secretmanager.secretAccessor / cloudsql.client / logging.logWriter) |
+
+> `template[0].containers[0].image` を `lifecycle.ignore_changes` 対象にし、Cloud Deploy 経由のリビジョン更新と Terraform の管理境界を分離している (AWS の `aws_ecs_service.task_definition` ignore と同じ思想)。
+
+### 5.5 データベース (Cloud SQL for PostgreSQL)
+
+| 項目 | 値 |
+|---|---|
+| エンジン | PostgreSQL 16 |
+| マシンタイプ | `db-custom-1-3840` (1 vCPU / 3.75GB)、`db-tier` 変数で変更可 |
+| 可用性 | ZONAL |
+| ディスク | PD_SSD 10GB (自動拡張) |
+| パブリックアクセス | 無効 (`ipv4_enabled = false`) |
+| Private IP | Service Networking ピアリング経由 |
+| 自動バックアップ | 02:00 JST 開始、30 件保持、PITR 有効 (7 日) |
+| クエリインサイト | 有効 (slow query = 1s 以上ログ) |
+| 接続情報 | DATABASE_URL を Secret Manager に格納 |
+| コネクションプール | `db-connection-limit` / `db-pool-timeout` 変数で Prisma 側を調整 |
+
+> Aurora Serverless v2 のような ACU 単位の自動スケーリングはないが、`db-tier` を変更することで縦スケールは可能。Aurora 同等の柔軟性が必要な場合は AlloyDB への切替を検討する。
+
+### 5.6 ロードバランサー (External Application LB)
+
+| 項目 | 値 |
+|---|---|
+| タイプ | External HTTPS Application LB (Global, EXTERNAL_MANAGED) |
+| フロントエンド | グローバル静的 IP + HTTPS:443 / HTTP:80 |
+| HTTP 動作 | `lb-domain` 設定時は HTTPS リダイレクト / 未設定時は HTTP 直接応答 (PoC 用) |
+| バックエンド (frontend) | Backend Bucket (GCS) + Cloud CDN 有効 |
+| バックエンド (backend) | Backend Service + Serverless NEG (Cloud Run) |
+| ヘルスチェック | Serverless NEG では不要 (Cloud Run 側 probe を使用) |
+| Cloud Armor | Backend Service / Backend Bucket の双方にアタッチ |
+
+### 5.7 Firewall ルール
+
+| ルール | 方向 | プロトコル/ポート | ソース/ターゲット |
+|---|---|---|---|
+| `bastion-ssh-from-iap` | INGRESS | TCP 22 | source: 35.235.240.0/20 (IAP), target tag: bastion |
+| `bastion-egress-db` | EGRESS | TCP 5432 | dest: PSA range, target tag: bastion |
+| `bastion-egress-https` | EGRESS | TCP 443 | dest: 0.0.0.0/0, target tag: bastion |
+| `deny-all-ingress` | INGRESS | ALL | source: 0.0.0.0/0, priority 65534 (デフォルト拒否の明示) |
+
+> Cloud Run → Cloud SQL は VPC Connector 経由で PSA range の Private IP に到達する。Cloud SQL Private IP 側は GCP マネージドネットワークで、VPC Firewall の制御対象外。
+
+### 5.8 Cloud Armor (WAF)
+
+LB Backend Service / Backend Bucket にアタッチした edge セキュリティポリシーで攻撃を遮断。
+
+| 優先度 | ルール | アクション |
+|---|---|---|
+| 1000 | SQL Injection (`sqli-v33-stable`) | deny(403) |
+| 1100 | XSS (`xss-v33-stable`) | deny(403) |
+| 1200 | Local File Inclusion (`lfi-v33-stable`) | deny(403) |
+| 1300 | Remote Code Execution (`rce-v33-stable`) | deny(403) |
+| 1400 | Protocol attack (`protocolattack-v33-stable`) | deny(403) |
+| 1500 | Scanner detection (`scannerdetection-v33-stable`) | deny(403) |
+| 2000 | `/api/*` レート制限 (2000 req/5min/IP) | rate_based_ban → deny(429), ban_duration=600s |
+| 2147483647 | デフォルト | allow |
+
+**Adaptive Protection (Layer 7 DDoS):** 有効化。ML ベースの異常検知。
+
+**ログ:** `log_level = VERBOSE`。LB request log の `jsonPayload.enforcedSecurityPolicy.*` フィールドに記録され、BigQuery sink (`*_armor_logs`) に転送される。
+
+### 5.9 監視アラート (Cloud Monitoring)
+
+Cloud Run / Cloud SQL の主要メトリクスを監視し、Pub/Sub トピック + Email チャネルへ通知する。
+
+| アラーム | メトリクス | 閾値 |
+|---|---|---|
+| `run-cpu-high` | Cloud Run container CPU utilization | > 80% (P99) |
+| `run-memory-high` | Cloud Run container memory utilization | > 80% (P99) |
+| `sql-cpu-high` | Cloud SQL CPU utilization | > 80% (mean) |
+| `sql-memory-high` | Cloud SQL memory utilization | > 80% (mean) |
+| `sql-connections-high` | PostgreSQL `num_backends` | > 70 (max) |
+| `sql-disk-high` | Cloud SQL disk utilization | > 80% (mean) |
+| `sql-disk-bytes-high` | Cloud SQL disk bytes used | > 100 GiB (max, 5分粒度) |
+
+- 評価間隔: 60秒、評価期間: 120秒 (連続 2 回超過で通知)
+- Pub/Sub トピック: `${app-name}-${environment}-alarms` (購読は Terraform 管理外)
+- Email チャネル: `alert-notification-emails` 変数の各アドレス
+
+### 5.10 CI/CD (Cloud Build + Cloud Deploy)
+
+**バックエンドパイプライン:**
+
+```
+GitHub (main push + backend/** 変更)
+  │
+  ▼
+Cloud Build Trigger (GitHub App / 2nd gen connection)
+  │ phases:
+  │   1. docker build (Dockerfile in backend src root)
+  │   2. push to Artifact Registry (latest + $SHORT_SHA)
+  │   3. gcloud deploy releases create → Cloud Deploy
+  │
+  ▼
+Cloud Deploy Delivery Pipeline (single-stage, prod target)
+  │ render & deploy
+  ▼
+Cloud Run (rolling deploy, ignore_changes で image のみ差分許可)
+```
+
+> Cloud Deploy ターゲットは `cloud-run` タイプ。リポジトリのバックエンド配下に `skaffold.yaml` + Cloud Run manifest (`run.googleapis.com/v1` Service yaml) を配置する必要がある。
+
+**フロントエンドパイプライン:**
+
+```
+GitHub (main push + frontend/** 変更)
+  │
+  ▼
+Cloud Build Trigger
+  │ phases:
+  │   1. node:22-slim + yarn install → yarn build (with .env injection)
+  │   2. gcloud storage rsync ./dist gs://${web} (index.html 除外)
+  │   3. gcloud storage cp ./dist/index.html → Cache-Control: no-store, no-cache
+  │   4. gcloud compute url-maps invalidate-cdn-cache (/*)
+```
+
+**事前準備:**
+- Cloud Build GitHub App を Cloud Console から承認
+- 2nd gen Repository Connection を作成し、リソース名を `cloudbuild-github-connection` 変数に設定 (例: `projects/PROJECT/locations/asia-northeast1/connections/github`)
+
+### 5.11 Auth0
+
+| リソース | 設定 |
+|---|---|
+| SPA クライアント (`${app-name}-${environment}-gcp-idp`) | authorization_code, implicit, refresh_token / Web Origin = `local.public_url` |
+| リソースサーバー (`${app-name}-${environment}-gcp-audience`) | identifier = `local.public_url`、RS256 |
+
+> `local.public_url` は `lb-domain` 設定時は `https://${lb-domain}`、未設定時は `http://${LB IP}`。
+
+### 5.12 自動起動・停止 (Cloud Scheduler + Cloud Workflows)
+
+| スケジュール | 時刻 (JST) | 対象 | デフォルト |
+|---|---|---|---|
+| Auto-stop | 毎日 13:00 | Cloud Run scaling → 0 / Cloud SQL `activationPolicy=NEVER` / Bastion VM 停止 | **有効** |
+| Auto-start | 土日 5:00 | Bastion 起動 → Cloud SQL `activationPolicy=ALWAYS` (12分待機) → Cloud Run scaling 復帰 | 無効 (paused) |
+
+**手動起動・停止:**
+
+Cloud Console (Workflows) または `gcloud workflows execute` でワークフローを直接起動できる。
+
+| Workflow 名 | 操作 |
+|---|---|
+| `${app-name}-${environment}-auto-stop` | 停止 |
+| `${app-name}-${environment}-auto-start` | 起動 |
+
+### 5.13 ログ分析 (BigQuery sinks)
+
+AWS の Athena (Glue Catalog) に相当。Cloud Logging のログを BigQuery にエクスポートし、`use_partitioned_tables = true` で日付パーティションテーブルを自動作成する。
+
+| Sink 名 | ソース | BigQuery データセット |
+|---|---|---|
+| `*-lb-logs` | `resource.type = http_load_balancer` | `${app_name}_${environment}_lb_logs` |
+| `*-run-logs` | `resource.type = cloud_run_revision` | `${app_name}_${environment}_cloud_run_logs` |
+| `*-armor-logs` | `enforcedSecurityPolicy.name = ${edge policy}` | `${app_name}_${environment}_armor_logs` |
+| `*-vpc-flow` | `logName = compute.googleapis.com/vpc_flows` | `${app_name}_${environment}_vpc_flow_logs` |
+
+> BigQuery テーブルは sink が初回ログ受信時に自動作成され、スキーマも Cloud Logging が自動推論する。AWS の RegexSerDe / partition projection 相当の設定は不要。
+
+---
+
+## 6. GitHub Actions CI (セキュリティスキャン)
 
 フロントエンド・バックエンドの Pull Request 時に Trivy でセキュリティスキャンを実行する。
 
@@ -553,31 +792,34 @@ Front Door キャッシュパージ
 
 ---
 
-## 6. AWS / Azure リソース対応表
+## 7. AWS / Azure / GCP リソース対応表
 
-| 機能 | AWS | Azure |
-|---|---|---|
-| CDN | CloudFront | Front Door Standard |
-| WAF | AWS WAF v2 (CloudFront scope) | — |
-| フロントエンドホスティング | S3 | Storage Account (静的Web) |
-| バックエンド実行環境 | ECS Fargate | App Service (Linux) |
-| コンテナレジストリ | ECR | ACR |
-| データベース | Aurora Serverless v2 | PostgreSQL Flexible Server |
-| DB長期バックアップ | AWS Backup (専用Vault) | PostgreSQL Flexible Server組込み (7日保持) |
-| シークレット管理 | SSM Parameter Store | Key Vault |
-| ネットワーク | VPC | VNet |
-| 踏み台 | EC2 Bastion | Azure Bastion |
-| CloudFrontアクセスログ | S3 (v2 CW Logs Delivery) | — |
-| WAFログ | S3 (direct logging) | — |
-| 監視アラーム | CloudWatch Alarms + SNS | — |
-| CI/CD | CodePipeline + CodeBuild | GitHub Actions |
-| 認証基盤 | Auth0 (Terraform管理) | Auth0 (Terraform管理) |
-| 監視ログ | CloudWatch Logs | Log Analytics Workspace |
-| CI/CD認証 | CodeStar Connection | OIDC (フェデレーテッド) |
+| 機能 | AWS | Azure | GCP |
+|---|---|---|---|
+| CDN | CloudFront | Front Door Standard | External Application LB + Cloud CDN |
+| WAF | AWS WAF v2 (CloudFront scope) | — | Cloud Armor (preconfigured WAF + Adaptive Protection) |
+| フロントエンドホスティング | S3 | Storage Account (静的Web) | Cloud Storage (`notFoundPage = index.html`) |
+| バックエンド実行環境 | ECS Fargate | App Service (Linux) | Cloud Run (v2) |
+| コンテナレジストリ | ECR | ACR | Artifact Registry |
+| データベース | Aurora Serverless v2 | PostgreSQL Flexible Server | Cloud SQL for PostgreSQL (Private IP) |
+| DB長期バックアップ | AWS Backup (専用Vault) | PostgreSQL Flexible Server組込み (7日保持) | Cloud SQL 自動バックアップ (30件) + PITR (7日) |
+| シークレット管理 | SSM Parameter Store | Key Vault | Secret Manager |
+| ネットワーク | VPC | VNet | VPC + Serverless VPC Access コネクタ |
+| 踏み台 | EC2 Bastion (Session Manager) | Azure Bastion | Compute Engine + IAP TCP forwarding |
+| CDN アクセスログ | S3 (v2 CW Logs Delivery) | — | Cloud Logging → BigQuery sink |
+| WAFログ | S3 (direct logging) | — | Cloud Logging → BigQuery sink |
+| 監視アラーム | CloudWatch Alarms + SNS | — | Cloud Monitoring + Pub/Sub + Email |
+| CI/CD | CodePipeline + CodeBuild | GitHub Actions | Cloud Build + Cloud Deploy |
+| 認証基盤 | Auth0 (Terraform管理) | Auth0 (Terraform管理) | Auth0 (Terraform管理) |
+| 監視ログ | CloudWatch Logs | Log Analytics Workspace | Cloud Logging |
+| CI/CD認証 | CodeStar Connection | OIDC (フェデレーテッド) | Cloud Build GitHub App (2nd gen Connection) |
+| 自動起動・停止 | EventBridge Scheduler + Step Functions | (なし) | Cloud Scheduler + Cloud Workflows |
+| ログ分析 | Athena (Glue Catalog) | Log Analytics KQL | BigQuery (Logging sink) |
+| プライベートサービス接続 | VPC Endpoint (Interface/Gateway) | Private Endpoint | Private Service Access (Service Networking) |
 
-## 7. Terraform 変数
+## 8. Terraform 変数
 
-### 7.1 共通変数
+### 8.1 共通変数
 
 | 変数名 | デフォルト | 説明 |
 |---|---|---|
@@ -585,7 +827,7 @@ Front Door キャッシュパージ
 | `auth0_client_id` | (必須) | Auth0 Client ID |
 | `auth0_client_secret` | (必須) | Auth0 Client Secret |
 | `github-repository-name` | (必須) | GitHubリポジトリ名 |
-| `app-name` | `sandbox-aws` / `sandbox` | アプリケーション名プレフィックス |
+| `app-name` | `sandbox-aws` / `sandbox` / `sandbox-gcp` | アプリケーション名プレフィックス |
 | `environment` | `dev` | 環境名 |
 | `frontend-src-root` | `frontend/sandbox-frontend` | フロントエンドのソースパス |
 | `backend-src-root` | `backend/sandbox-backend` | バックエンドのソースパス |
@@ -597,7 +839,7 @@ Front Door キャッシュパージ
 | `db-connection-limit` | `5` | Prismaコネクションプール上限（設定指針は 3.5.1 参照） |
 | `db-pool-timeout` | `15` | Prismaコネクション空き待ちタイムアウト（秒） |
 
-### 7.2 AWS固有変数
+### 8.2 AWS固有変数
 
 | 変数名 | デフォルト | 説明 |
 |---|---|---|
@@ -606,7 +848,7 @@ Front Door キャッシュパージ
 | `subnet_private1a_cidr_block` | `172.16.2.0/24` | プライベートサブネット1 CIDR |
 | `subnet_private1c_cidr_block` | `172.16.3.0/24` | プライベートサブネット2 CIDR |
 
-### 7.3 Azure固有変数
+### 8.3 Azure固有変数
 
 | 変数名 | デフォルト | 説明 |
 |---|---|---|
@@ -616,9 +858,25 @@ Front Door キャッシュパージ
 | `public-key-vault-rg-name` | `""` | 公開Key Vaultリソースグループ名 |
 | `public-key-vault-secret` | `""` | 公開Key Vaultシークレット |
 
-## 8. デプロイ手順
+### 8.4 GCP固有変数
 
-### 8.1 初回セットアップ
+| 変数名 | デフォルト | 説明 |
+|---|---|---|
+| `gcp-project-id` | (必須) | GCP プロジェクト ID |
+| `gcp-region` | `asia-northeast1` | GCP リージョン (東京) |
+| `gcp-zone` | `asia-northeast1-a` | GCP ゾーン (Bastion VM 配置先) |
+| `github-owner` | (必須) | GitHub Owner 名 |
+| `cloudbuild-github-connection` | `""` | Cloud Build GitHub Connection リソース名 |
+| `subnet_primary_cidr_block` | `172.16.2.0/24` | プライマリサブネット CIDR |
+| `subnet_connector_cidr_block` | `172.16.4.0/28` | Serverless VPC コネクタ専用 /28 サブネット |
+| `psa_range_cidr_block` | `172.16.16.0/20` | Private Service Access 用予約 IP レンジ |
+| `db-tier` | `db-custom-1-3840` | Cloud SQL マシンタイプ |
+| `lb-domain` | `""` | LB 公開ドメイン (Managed SSL + HTTPS リダイレクト用) |
+| `alert-notification-emails` | `[]` | Cloud Monitoring アラート通知先 Email |
+
+## 9. デプロイ手順
+
+### 9.1 初回セットアップ
 
 ```bash
 # AWS
@@ -634,9 +892,18 @@ cp terraform.tfvars.example terraform.tfvars  # 変数を編集
 terraform init
 terraform plan
 terraform apply
+
+# GCP
+cd iac/gcp
+# 事前に gcloud auth application-default login で ADC を設定
+# Cloud Build GitHub App を Cloud Console から承認し、2nd gen Connection を作成しておく
+cp terraform.tfvars.example terraform.tfvars  # 変数を編集
+terraform init
+terraform plan
+terraform apply
 ```
 
-### 8.2 アプリケーションデプロイ
+### 9.2 アプリケーションデプロイ
 
 **AWS:**
 - `main` ブランチへのpushでCodePipelineが自動トリガー
@@ -647,18 +914,25 @@ terraform apply
 - GitHub Actionsワークフローを手動実行 (`workflow_dispatch`)
 - Key Vaultから動的に設定値を取得
 
-## 9. セキュリティ設計
+**GCP:**
+- `main` ブランチへのpushでCloud Build Triggerが自動発火
+- バックエンド: `backend/**` 変更で `cloud_build_backend` トリガー → Cloud Deploy 経由で Cloud Run 更新
+- フロントエンド: `frontend/**` 変更で `cloud_build_frontend` トリガー → GCS sync + Cloud CDN invalidation
 
-| セキュリティ施策 | AWS | Azure |
-|---|---|---|
-| DB非公開 | プライベートサブネット | VNet統合 + パブリックアクセス無効 |
-| シークレット管理 | SSM Parameter Store (SecureString) | Key Vault |
-| CDNオリジン保護 | OAC (S3), VPC Origin (ALB) | IP制限 (Front Door Backend) |
-| CI/CD認証 | CodeStar Connection | OIDC (フェデレーテッド資格情報) |
-| コンテナレジストリ | プライベートECR | Managed Identity (AcrPull) |
-| 通信暗号化 | HTTPS リダイレクト | HTTPS (Front Door) |
-| ストレージ暗号化 | Aurora暗号化有効 | - |
-| バックアップ暗号化 | AWS Backup Vault (`aws/backup` KMSキー) | PostgreSQLサービス組込み |
-| アクセス制御 | セキュリティグループ | NSG + サブネットデリゲーション |
-| SG egress 最小化 | ALB/ECS/DB/Bastion/SSM endpoint の egress を用途別ポート・宛先に限定（DB egress なし） | — |
-| IAM 最小権限 | CodePipeline ECS権限を特定タスク定義・クラスタ ARN に限定 | — |
+## 10. セキュリティ設計
+
+| セキュリティ施策 | AWS | Azure | GCP |
+|---|---|---|---|
+| DB非公開 | プライベートサブネット | VNet統合 + パブリックアクセス無効 | Private IP (PSA) + `ipv4_enabled = false` |
+| シークレット管理 | SSM Parameter Store (SecureString) | Key Vault | Secret Manager (user_managed replication) |
+| CDNオリジン保護 | OAC (S3), VPC Origin (ALB) | IP制限 (Front Door Backend) | Cloud Run `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` + GCS public_access_prevention |
+| CI/CD認証 | CodeStar Connection | OIDC (フェデレーテッド資格情報) | Cloud Build GitHub App (2nd gen Connection) |
+| コンテナレジストリ | プライベートECR | Managed Identity (AcrPull) | Artifact Registry (Cloud Run ランタイム SA に reader 付与) |
+| 通信暗号化 | HTTPS リダイレクト | HTTPS (Front Door) | HTTPS リダイレクト (`lb-domain` 設定時 Managed SSL) |
+| ストレージ暗号化 | Aurora暗号化有効 | - | Cloud SQL (デフォルトで保存時暗号化、GMEK) |
+| バックアップ暗号化 | AWS Backup Vault (`aws/backup` KMSキー) | PostgreSQLサービス組込み | Cloud SQL 自動バックアップ (Google マネージド暗号化) |
+| アクセス制御 | セキュリティグループ | NSG + サブネットデリゲーション | VPC Firewall (target tags + IAP source range) |
+| 最小権限ルール | ALB/ECS/DB/Bastion/SSM endpoint の egress を用途別ポート・宛先に限定（DB egress なし） | — | Bastion egress を 443 / 5432 + PSA range に限定、 SSH は IAP `35.235.240.0/20` のみ許可 |
+| IAM 最小権限 | CodePipeline ECS権限を特定タスク定義・クラスタ ARN に限定 | — | Cloud Build SA に `artifactregistry.writer` / `clouddeploy.releaser` のみ付与、deploy 用 SA を分離 |
+| WAF | AWS WAF v2 (managed rule groups) | — | Cloud Armor (preconfigured WAF + Adaptive Protection) |
+| 踏み台アクセス | EC2 + SSM Session Manager (SSH キー不要) | Azure Bastion | IAP TCP forwarding (gcloud `--tunnel-through-iap`) — public IP なし、SSH キー不要 |

--- a/iac/gcp/artifact_registry.tf
+++ b/iac/gcp/artifact_registry.tf
@@ -1,0 +1,12 @@
+# Artifact Registry: AWS の ECR 相当
+# バックエンド Docker イメージを保管 (Cloud Run が pull する)
+resource "google_artifact_registry_repository" "backend" {
+  location      = var.gcp-region
+  repository_id = "${var.environment}-${var.app-name}-backend"
+  format        = "DOCKER"
+  description   = "Backend container images for ${var.app-name}-${var.environment}"
+
+  # 脆弱性スキャンは Artifact Analysis (旧 Container Analysis) で別途有効化
+  # ProjectService で containeranalysis.googleapis.com を追加することで自動スキャン
+  depends_on = [google_project_service.services]
+}

--- a/iac/gcp/auth0.tf
+++ b/iac/gcp/auth0.tf
@@ -1,0 +1,33 @@
+# Auth0アプリケーション (SPA): フロントエンドからの認証フロー用クライアント
+# - コールバック / ログアウト / Web Origin に LB の公開 URL を許可
+resource "auth0_client" "app" {
+  allowed_logout_urls = [
+    local.public_url,
+  ]
+  app_type = "spa"
+  callbacks = [
+    local.public_url,
+  ]
+  cross_origin_auth = false
+  grant_types = [
+    "authorization_code",
+    "implicit",
+    "refresh_token",
+  ]
+  name            = "${var.app-name}-${var.environment}-gcp-idp"
+  oidc_conformant = true
+  web_origins = [
+    local.public_url,
+  ]
+
+  jwt_configuration {
+    alg = "RS256"
+  }
+}
+
+# Auth0 API (Resource Server): バックエンドが検証するアクセストークンの audience を定義
+resource "auth0_resource_server" "audience" {
+  name        = "${var.app-name}-${var.environment}-gcp-audience"
+  identifier  = local.public_url
+  signing_alg = "RS256"
+}

--- a/iac/gcp/bastion.tf
+++ b/iac/gcp/bastion.tf
@@ -1,0 +1,80 @@
+# Bastion VM: AWS の EC2 Bastion + Session Manager 相当
+# - IAP TCP forwarding 経由で SSH 接続 (gcloud compute ssh --tunnel-through-iap)
+# - Cloud SQL Private IP に対する psql ポートフォワード等で利用
+# - パブリック IP なし、firewall は 35.235.240.0/20 (IAP) からのみ SSH 許可
+
+# Bastion 用 SA
+resource "google_service_account" "bastion" {
+  account_id   = "${var.app-name}-${var.environment}-bastion"
+  display_name = "Bastion VM SA for ${var.app-name}-${var.environment}"
+}
+
+# Cloud SQL クライアント権限 (psql からの接続でも有用)
+resource "google_project_iam_member" "bastion_sql_client" {
+  project = var.gcp-project-id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.bastion.email}"
+}
+
+# Secret Manager 参照権限 (運用時に DATABASE_URL を取得するため)
+resource "google_project_iam_member" "bastion_secret_accessor" {
+  project = var.gcp-project-id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.bastion.email}"
+}
+
+# Cloud Logging への書き込み権限
+resource "google_project_iam_member" "bastion_logwriter" {
+  project = var.gcp-project-id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.bastion.email}"
+}
+
+# Bastion VM 本体
+# IAP TCP forwarding 経由で SSH するため public IP は付与しない
+resource "google_compute_instance" "bastion" {
+  name         = "${var.app-name}-${var.environment}-bastion"
+  machine_type = "e2-micro"
+  zone         = var.gcp-zone
+
+  tags = ["bastion"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+      size  = 30
+      type  = "pd-balanced"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.vpc.name
+    subnetwork = google_compute_subnetwork.primary.name
+    # public IP 無し (IAP TCP forwarding を経由するため)
+  }
+
+  service_account {
+    email  = google_service_account.bastion.email
+    scopes = ["cloud-platform"]
+  }
+
+  # cloud-sql-proxy / postgresql-client を事前インストールしておく
+  metadata_startup_script = <<-EOT
+    #!/bin/bash
+    set -eux
+    apt-get update
+    apt-get install -y postgresql-client wget
+    wget -qO /usr/local/bin/cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.11.4/cloud-sql-proxy.linux.amd64
+    chmod +x /usr/local/bin/cloud-sql-proxy
+  EOT
+
+  # 自動停止対象として扱えるよう、起動順序の依存関係を明示
+  depends_on = [
+    google_compute_router_nat.nat,
+    google_service_networking_connection.psa,
+  ]
+}
+
+# 任意の IAM ユーザ/グループに Bastion への IAP TCP 接続権限を付与するための
+# IAM ロールバインディングは Terraform 外で管理 (環境ごとに変動するため)。
+# 必要に応じて roles/iap.tunnelResourceAccessor を VM スコープで付与すること。

--- a/iac/gcp/bigquery_log_sinks.tf
+++ b/iac/gcp/bigquery_log_sinks.tf
@@ -1,0 +1,134 @@
+# Cloud Logging → BigQuery sink: AWS の Athena (Glue Catalog) 相当
+# Cloud Logging はサービスログを構造化 JSON のまま吐き出すため、
+# AWS のように RegexSerDe や partition projection を組む必要はない。
+# BigQuery 側は use_partitioned_tables = true で日付パーティションテーブルを自動作成する。
+#
+# AWS との対応:
+#   ALB アクセスログ (Glue table)   → LB request log sink → BigQuery
+#   CloudFront アクセスログ          → LB request log sink (上記と同じ — LB が CDN を兼ねる)
+#   ECS コンテナログ (Athena)        → Cloud Run コンテナログ sink → BigQuery
+#   WAF ログ (Athena)                → Cloud Armor ログ sink → BigQuery
+#   VPC Flow Logs (Athena)           → Compute Engine flow logs sink → BigQuery
+
+# 共通: ログ専用 BigQuery データセット (テーブルは sink が動的に作成)
+resource "google_bigquery_dataset" "lb_logs" {
+  dataset_id  = replace("${var.app-name}_${var.environment}_lb_logs", "-", "_")
+  location    = var.gcp-region
+  description = "External Application LB request logs (CloudFront + ALB アクセスログ相当)"
+
+  default_table_expiration_ms = 31536000000 # 365日
+}
+
+resource "google_bigquery_dataset" "cloud_run_logs" {
+  dataset_id  = replace("${var.app-name}_${var.environment}_cloud_run_logs", "-", "_")
+  location    = var.gcp-region
+  description = "Cloud Run コンテナログ (AWS ECS / FireLens 相当)"
+
+  default_table_expiration_ms = 31536000000
+}
+
+resource "google_bigquery_dataset" "armor_logs" {
+  dataset_id  = replace("${var.app-name}_${var.environment}_armor_logs", "-", "_")
+  location    = var.gcp-region
+  description = "Cloud Armor (WAF) ログ"
+
+  default_table_expiration_ms = 31536000000
+}
+
+resource "google_bigquery_dataset" "vpc_flow_logs" {
+  dataset_id  = replace("${var.app-name}_${var.environment}_vpc_flow_logs", "-", "_")
+  location    = var.gcp-region
+  description = "VPC Flow Logs"
+
+  default_table_expiration_ms = 31536000000
+}
+
+# ---------- LB アクセスログ ----------
+# Cloud Logging で resource.type = "http_load_balancer" がエクスポート対象
+resource "google_logging_project_sink" "lb_logs" {
+  name        = "${var.app-name}-${var.environment}-lb-logs"
+  destination = "bigquery.googleapis.com/projects/${var.gcp-project-id}/datasets/${google_bigquery_dataset.lb_logs.dataset_id}"
+
+  filter = "resource.type=\"http_load_balancer\" AND resource.labels.url_map_name=\"${google_compute_url_map.main.name}\""
+
+  unique_writer_identity = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset_iam_member" "lb_logs_writer" {
+  dataset_id = google_bigquery_dataset.lb_logs.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = google_logging_project_sink.lb_logs.writer_identity
+}
+
+# ---------- Cloud Run コンテナログ ----------
+resource "google_logging_project_sink" "cloud_run_logs" {
+  name        = "${var.app-name}-${var.environment}-run-logs"
+  destination = "bigquery.googleapis.com/projects/${var.gcp-project-id}/datasets/${google_bigquery_dataset.cloud_run_logs.dataset_id}"
+
+  filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${google_cloud_run_v2_service.backend.name}\""
+
+  unique_writer_identity = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset_iam_member" "cloud_run_logs_writer" {
+  dataset_id = google_bigquery_dataset.cloud_run_logs.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = google_logging_project_sink.cloud_run_logs.writer_identity
+}
+
+# ---------- Cloud Armor (WAF) ログ ----------
+# Cloud Armor のログは LB request log の jsonPayload.enforcedSecurityPolicy 等に紛れ込むが、
+# 専用ストリーム (enforcedSecurityPolicy.name = "<policy name>") でフィルタしてエクスポート
+resource "google_logging_project_sink" "armor_logs" {
+  name        = "${var.app-name}-${var.environment}-armor-logs"
+  destination = "bigquery.googleapis.com/projects/${var.gcp-project-id}/datasets/${google_bigquery_dataset.armor_logs.dataset_id}"
+
+  filter = join(" AND ", [
+    "resource.type=\"http_load_balancer\"",
+    "jsonPayload.enforcedSecurityPolicy.name=\"${google_compute_security_policy.edge.name}\"",
+  ])
+
+  unique_writer_identity = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset_iam_member" "armor_logs_writer" {
+  dataset_id = google_bigquery_dataset.armor_logs.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = google_logging_project_sink.armor_logs.writer_identity
+}
+
+# ---------- VPC Flow Logs ----------
+# VPC Flow Logs は resource.type = "gce_subnetwork" でフィルタ
+resource "google_logging_project_sink" "vpc_flow_logs" {
+  name        = "${var.app-name}-${var.environment}-vpc-flow"
+  destination = "bigquery.googleapis.com/projects/${var.gcp-project-id}/datasets/${google_bigquery_dataset.vpc_flow_logs.dataset_id}"
+
+  filter = join(" AND ", [
+    "resource.type=\"gce_subnetwork\"",
+    "logName=\"projects/${var.gcp-project-id}/logs/compute.googleapis.com%2Fvpc_flows\"",
+  ])
+
+  unique_writer_identity = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset_iam_member" "vpc_flow_logs_writer" {
+  dataset_id = google_bigquery_dataset.vpc_flow_logs.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = google_logging_project_sink.vpc_flow_logs.writer_identity
+}

--- a/iac/gcp/cloud_armor.tf
+++ b/iac/gcp/cloud_armor.tf
@@ -1,0 +1,142 @@
+# Cloud Armor セキュリティポリシー: AWS WAF v2 (CloudFront scope) 相当
+# 外部 Application LB にアタッチし、エッジで攻撃を遮断する。
+#
+# ルール構成 (AWS の WAF と概ね整合):
+#   priority 1000: SQL Injection (OWASP ModSec CRS)         ≒ AWSManagedRulesCommonRuleSet (SQLi 部分)
+#   priority 1100: XSS                                       ≒ AWSManagedRulesCommonRuleSet (XSS 部分)
+#   priority 1200: Local File Inclusion                      ≒ AWSManagedRulesCommonRuleSet (LFI 部分)
+#   priority 1300: Remote Code Execution                     ≒ AWSManagedRulesKnownBadInputsRuleSet
+#   priority 1400: Method enforcement / protocol attack      ≒ AWSManagedRulesCommonRuleSet
+#   priority 1500: Scanner detection                         ≒ 同上
+#   priority 2000: /api/* レート制限 (5分/IP/2000リクエスト) ≒ RateLimitApi
+#   priority 2147483647 (default): allow
+#
+# AWS WAF の AWSManagedRulesAmazonIpReputationList に直接対応するルールは無いが、
+# Cloud Armor Adaptive Protection (priority 別管理) を併用する想定。
+resource "google_compute_security_policy" "edge" {
+  name        = "${var.app-name}-${var.environment}-edge-policy"
+  description = "Edge WAF policy for ${var.app-name}-${var.environment}"
+  type        = "CLOUD_ARMOR"
+
+  # Adaptive Protection: ML ベースの異常検知 (AWS WAF にはない GCP 独自機能)
+  adaptive_protection_config {
+    layer_7_ddos_defense_config {
+      enable = true
+    }
+  }
+
+  # ルール: SQL Injection
+  rule {
+    action   = "deny(403)"
+    priority = 1000
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1})"
+      }
+    }
+    description = "SQL Injection (preconfigured WAF)"
+  }
+
+  # ルール: XSS
+  rule {
+    action   = "deny(403)"
+    priority = 1100
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable', {'sensitivity': 1})"
+      }
+    }
+    description = "Cross-site scripting (preconfigured WAF)"
+  }
+
+  # ルール: Local File Inclusion
+  rule {
+    action   = "deny(403)"
+    priority = 1200
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('lfi-v33-stable', {'sensitivity': 1})"
+      }
+    }
+    description = "Local File Inclusion (preconfigured WAF)"
+  }
+
+  # ルール: Remote Code Execution
+  rule {
+    action   = "deny(403)"
+    priority = 1300
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable', {'sensitivity': 1})"
+      }
+    }
+    description = "Remote Code Execution (preconfigured WAF)"
+  }
+
+  # ルール: Protocol attack (HTTP smuggling, response splitting 等)
+  rule {
+    action   = "deny(403)"
+    priority = 1400
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1})"
+      }
+    }
+    description = "Protocol attack (preconfigured WAF)"
+  }
+
+  # ルール: Scanner detection
+  rule {
+    action   = "deny(403)"
+    priority = 1500
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable', {'sensitivity': 1})"
+      }
+    }
+    description = "Scanner detection (preconfigured WAF)"
+  }
+
+  # ルール: /api/* レート制限 (5分間で2000リクエスト/IP)
+  # AWS の RateLimitApi (5分 2000req/IP) に揃える
+  rule {
+    action   = "rate_based_ban"
+    priority = 2000
+    rate_limit_options {
+      conform_action = "allow"
+      exceed_action  = "deny(429)"
+      enforce_on_key = "IP"
+      rate_limit_threshold {
+        count        = 2000
+        interval_sec = 300
+      }
+      ban_duration_sec = 600
+    }
+    match {
+      expr {
+        expression = "request.path.startsWith('/api/')"
+      }
+    }
+    description = "Rate limit on /api/* (2000 req / 5min / IP)"
+  }
+
+  # デフォルトルール: 全てのトラフィックを許可
+  # (priority 2147483647 = INT_MAX。固定値で1ポリシーに必ず1つ存在)
+  rule {
+    action   = "allow"
+    priority = 2147483647
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "Default rule, higher priority overrides it"
+  }
+
+  # ログ: Cloud Armor のログは Cloud Logging に出力される
+  # BigQuery への転送は bigquery_armor_logs.tf で sink 設定
+  advanced_options_config {
+    log_level = "VERBOSE"
+  }
+}

--- a/iac/gcp/cloud_build_backend.tf
+++ b/iac/gcp/cloud_build_backend.tf
@@ -1,0 +1,170 @@
+# バックエンド CI/CD: Cloud Build → Artifact Registry → Cloud Deploy → Cloud Run
+# AWS の CodePipeline (Source/Build/Deploy) と機能パリティ:
+#   - Cloud Build trigger : GitHub push 検知 + 変更パスフィルタ
+#   - inline build steps  : docker build → Artifact Registry push (AWS CodeBuild 相当)
+#   - Cloud Deploy        : Cloud Run 本番デプロイ (AWS の ECS Deploy ステージ相当)
+#
+# 前提:
+#   - Cloud Build GitHub App / Cloud Build GitHub Connection を事前承認し、
+#     var.cloudbuild-github-connection に Connection リソース名を指定すること
+#   - リポジトリのバックエンド配下に skaffold.yaml と cloud-run-service.yaml (manifests) を配置
+#     (Cloud Deploy の cloud-run ターゲットは skaffold.yaml + manifest が必須)
+
+# Cloud Build SA (バックエンドビルド+デプロイ専用)
+resource "google_service_account" "cloudbuild_backend" {
+  account_id   = "${var.app-name}-${var.environment}-cb-backend"
+  display_name = "Cloud Build SA for backend pipeline"
+}
+
+# 必要な IAM (Artifact Registry push / Cloud Deploy release / Cloud Run 更新 / Logging)
+resource "google_project_iam_member" "cb_backend_ar_writer" {
+  project = var.gcp-project-id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.cloudbuild_backend.email}"
+}
+
+resource "google_project_iam_member" "cb_backend_clouddeploy_releaser" {
+  project = var.gcp-project-id
+  role    = "roles/clouddeploy.releaser"
+  member  = "serviceAccount:${google_service_account.cloudbuild_backend.email}"
+}
+
+resource "google_project_iam_member" "cb_backend_logwriter" {
+  project = var.gcp-project-id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloudbuild_backend.email}"
+}
+
+# Cloud Build から Cloud Deploy 経由で Cloud Run を更新する際の SA 借用権限
+resource "google_service_account_iam_member" "cb_backend_act_as_clouddeploy" {
+  service_account_id = google_service_account.clouddeploy_runner.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.cloudbuild_backend.email}"
+}
+
+# Cloud Deploy が実際に Cloud Run を更新する SA
+# AWS の ECS Deploy で使う execute_ecs_task に該当する役割
+resource "google_service_account" "clouddeploy_runner" {
+  account_id   = "${var.app-name}-${var.environment}-deploy"
+  display_name = "Cloud Deploy runner SA"
+}
+
+resource "google_project_iam_member" "clouddeploy_runner_run_admin" {
+  project = var.gcp-project-id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.clouddeploy_runner.email}"
+}
+
+# Cloud Run の SA を借用して image を差し替えるため
+resource "google_service_account_iam_member" "clouddeploy_runner_act_as_run" {
+  service_account_id = google_service_account.cloud_run.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.clouddeploy_runner.email}"
+}
+
+# Cloud Deploy ターゲット: 本番 Cloud Run
+resource "google_clouddeploy_target" "prod" {
+  location = var.gcp-region
+  name     = "${var.app-name}-${var.environment}-target"
+
+  run {
+    location = "projects/${var.gcp-project-id}/locations/${var.gcp-region}"
+  }
+
+  execution_configs {
+    usages          = ["RENDER", "DEPLOY"]
+    service_account = google_service_account.clouddeploy_runner.email
+  }
+
+  depends_on = [google_project_service.services]
+}
+
+# Cloud Deploy デリバリーパイプライン: 単一ステージ (本番) のローリングデプロイ
+resource "google_clouddeploy_delivery_pipeline" "backend" {
+  location = var.gcp-region
+  name     = "${var.app-name}-${var.environment}-backend-pipeline"
+
+  serial_pipeline {
+    stages {
+      target_id = google_clouddeploy_target.prod.name
+      profiles  = []
+    }
+  }
+}
+
+# Cloud Build トリガー: main push + backend/** 変更で発火
+# Build phase で docker build → AR push、その後 gcloud deploy releases create でデプロイ
+resource "google_cloudbuild_trigger" "backend" {
+  name            = "${var.app-name}-${var.environment}-backend"
+  location        = var.gcp-region
+  service_account = google_service_account.cloudbuild_backend.id
+  included_files  = ["${var.backend-src-root}/**"]
+
+  repository_event_config {
+    repository = var.cloudbuild-github-connection == "" ? null : "${var.cloudbuild-github-connection}/repositories/${replace(var.github-repository-name, "/", "-")}"
+
+    push {
+      branch = "^${var.target-branch}$"
+    }
+  }
+
+  build {
+    timeout = "1200s"
+    options {
+      logging = "CLOUD_LOGGING_ONLY"
+    }
+
+    # docker build
+    step {
+      id   = "build"
+      name = "gcr.io/cloud-builders/docker"
+      dir  = var.backend-src-root
+      args = [
+        "build",
+        "-t", "${var.gcp-region}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:$SHORT_SHA",
+        "-t", "${var.gcp-region}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:latest",
+        "-f", "Dockerfile",
+        ".",
+      ]
+    }
+
+    # push (latest + short SHA)
+    step {
+      id   = "push-sha"
+      name = "gcr.io/cloud-builders/docker"
+      args = ["push", "${var.gcp-region}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:$SHORT_SHA"]
+    }
+    step {
+      id   = "push-latest"
+      name = "gcr.io/cloud-builders/docker"
+      args = ["push", "${var.gcp-region}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:latest"]
+    }
+
+    # Cloud Deploy へリリース投入 (skaffold.yaml が backend src root にある前提)
+    step {
+      id         = "release"
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+      entrypoint = "bash"
+      dir        = var.backend-src-root
+      args = [
+        "-c",
+        join(" ", [
+          "gcloud deploy releases create rel-$SHORT_SHA",
+          "--delivery-pipeline=${google_clouddeploy_delivery_pipeline.backend.name}",
+          "--region=${var.gcp-region}",
+          "--images=backend=${var.gcp-region}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:$SHORT_SHA",
+        ]),
+      ]
+    }
+
+    images = [
+      "${var.gcp-region}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:$SHORT_SHA",
+      "${var.gcp-region}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:latest",
+    ]
+  }
+
+  depends_on = [
+    google_project_iam_member.cb_backend_ar_writer,
+    google_project_iam_member.cb_backend_clouddeploy_releaser,
+  ]
+}

--- a/iac/gcp/cloud_build_frontend.tf
+++ b/iac/gcp/cloud_build_frontend.tf
@@ -1,0 +1,118 @@
+# フロントエンド CI/CD: Cloud Build → GCS sync → Cloud CDN invalidation
+# AWS の CodePipeline frontend (Source/Build → S3 sync + CloudFront invalidation) と同等
+#
+# 前提:
+#   - Cloud Build GitHub Connection を事前承認 (バックエンド側と共有)
+#   - skaffold は不要 (静的アセットのため Cloud Deploy は使わない)
+
+# Cloud Build SA (フロントエンドデプロイ専用)
+resource "google_service_account" "cloudbuild_frontend" {
+  account_id   = "${var.app-name}-${var.environment}-cb-front"
+  display_name = "Cloud Build SA for frontend pipeline"
+}
+
+# GCS バケットへの書き込み権限
+resource "google_storage_bucket_iam_member" "cb_frontend_writer" {
+  bucket = google_storage_bucket.web.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloudbuild_frontend.email}"
+}
+
+# Cloud CDN キャッシュ無効化権限
+resource "google_project_iam_member" "cb_frontend_cdn_invalidator" {
+  project = var.gcp-project-id
+  role    = "roles/compute.loadBalancerAdmin"
+  member  = "serviceAccount:${google_service_account.cloudbuild_frontend.email}"
+}
+
+resource "google_project_iam_member" "cb_frontend_logwriter" {
+  project = var.gcp-project-id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloudbuild_frontend.email}"
+}
+
+# Cloud Build トリガー: main push + frontend/** 変更で発火
+resource "google_cloudbuild_trigger" "frontend" {
+  name            = "${var.app-name}-${var.environment}-frontend"
+  location        = var.gcp-region
+  service_account = google_service_account.cloudbuild_frontend.id
+  included_files  = ["${var.frontend-src-root}/**"]
+
+  repository_event_config {
+    repository = var.cloudbuild-github-connection == "" ? null : "${var.cloudbuild-github-connection}/repositories/${replace(var.github-repository-name, "/", "-")}"
+
+    push {
+      branch = "^${var.target-branch}$"
+    }
+  }
+
+  build {
+    timeout = "900s"
+    options {
+      logging = "CLOUD_LOGGING_ONLY"
+    }
+
+    # Node 22 + yarn セットアップ → ビルド
+    step {
+      id         = "install-build"
+      name       = "node:22-slim"
+      entrypoint = "bash"
+      dir        = var.frontend-src-root
+      args = [
+        "-c",
+        join(" && ", [
+          "corepack enable",
+          "yarn --version",
+          "cat > .env <<EOF\nVITE_AUTH0_DOMAIN=${var.auth0_domain}\nVITE_AUTH0_CLIENT_ID=${auth0_client.app.client_id}\nVITE_AUTH0_AUDIENCE=${local.public_url}\nVITE_API_BASE_URL=${local.public_url}\nEOF",
+          "yarn install --frozen-lockfile",
+          "yarn build",
+        ]),
+      ]
+    }
+
+    # GCS sync (index.html を除く)
+    step {
+      id         = "sync-assets"
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+      entrypoint = "bash"
+      dir        = var.frontend-src-root
+      args = [
+        "-c",
+        "gcloud storage rsync ./dist gs://${google_storage_bucket.web.name}/ --recursive --delete-unmatched-destination-objects --exclude='index.html'",
+      ]
+    }
+
+    # index.html を Cache-Control no-store, no-cache 付きでアップロード
+    step {
+      id         = "upload-index"
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+      entrypoint = "bash"
+      dir        = var.frontend-src-root
+      args = [
+        "-c",
+        "gcloud storage cp ./dist/index.html gs://${google_storage_bucket.web.name}/index.html --cache-control='no-store, no-cache'",
+      ]
+    }
+
+    # Cloud CDN キャッシュ無効化 (/* 全パス)
+    step {
+      id         = "invalidate"
+      name       = "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        join(" ", [
+          "gcloud compute url-maps invalidate-cdn-cache ${google_compute_url_map.main.name}",
+          "--path '/*'",
+          "--global",
+          "--async",
+        ]),
+      ]
+    }
+  }
+
+  depends_on = [
+    google_storage_bucket_iam_member.cb_frontend_writer,
+    google_project_iam_member.cb_frontend_cdn_invalidator,
+  ]
+}

--- a/iac/gcp/cloud_run.tf
+++ b/iac/gcp/cloud_run.tf
@@ -1,0 +1,174 @@
+# Cloud Run サービス: AWS の ECS Fargate + ALB Target Group 相当
+# - サーバーレス、スケール 0〜N
+# - Serverless VPC Access コネクタ経由で VPC 内の Cloud SQL Private IP に到達
+# - イメージは Artifact Registry から pull
+# - 環境変数 / シークレットは Secret Manager から注入
+
+# Cloud Run サービス用のランタイム SA
+# AWS の aws_iam_role.ecs_task 相当 (コンテナアプリ自身が AWS API を呼ぶときのロール)
+resource "google_service_account" "cloud_run" {
+  account_id   = "${var.app-name}-${var.environment}-run"
+  display_name = "Cloud Run runtime SA for ${var.app-name}-${var.environment}"
+}
+
+# Secret Manager のシークレット参照権限
+# AWS の execute_ecs_task の ssm:GetParameters 相当
+resource "google_project_iam_member" "cloud_run_secret_accessor" {
+  project = var.gcp-project-id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+# Artifact Registry の pull 権限
+# AWS の execute_ecs_task の ecr:* 相当
+resource "google_artifact_registry_repository_iam_member" "cloud_run_ar_reader" {
+  location   = google_artifact_registry_repository.backend.location
+  repository = google_artifact_registry_repository.backend.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+# Cloud SQL クライアント権限 (Private IP 経由でも IAM 認証/接続性のため付与)
+resource "google_project_iam_member" "cloud_run_sql_client" {
+  project = var.gcp-project-id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+# Cloud Logging への書き込み権限 (デフォルトで Cloud Run コンテナログが出力される)
+resource "google_project_iam_member" "cloud_run_logwriter" {
+  project = var.gcp-project-id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+# Cloud Run サービス本体
+resource "google_cloud_run_v2_service" "backend" {
+  name                = "${var.app-name}-${var.environment}-service"
+  location            = var.gcp-region
+  ingress             = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  deletion_protection = false
+
+  template {
+    service_account = google_service_account.cloud_run.email
+
+    # AWS タスク定義 CPU=256 / Memory=512 と同等規模の最小構成
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 10
+    }
+
+    # Serverless VPC Access コネクタ経由で VPC 内 Cloud SQL に到達
+    # egress = PRIVATE_RANGES_ONLY: NAT を介さず VPC 内 Private IP のみコネクタへ
+    vpc_access {
+      connector = google_vpc_access_connector.connector.id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    containers {
+      image = "${google_artifact_registry_repository.backend.location}-docker.pkg.dev/${var.gcp-project-id}/${google_artifact_registry_repository.backend.repository_id}/backend:latest"
+
+      ports {
+        container_port = var.api-expose-port
+      }
+
+      resources {
+        cpu_idle = true
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      # ヘルスチェック (Cloud Run startup / liveness probe)
+      startup_probe {
+        http_get {
+          path = var.health-check-path
+          port = var.api-expose-port
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 10
+        timeout_seconds       = 3
+        failure_threshold     = 6
+      }
+
+      liveness_probe {
+        http_get {
+          path = var.health-check-path
+          port = var.api-expose-port
+        }
+        period_seconds    = 30
+        timeout_seconds   = 5
+        failure_threshold = 3
+      }
+
+      env {
+        name  = "PORT"
+        value = tostring(var.api-expose-port)
+      }
+      env {
+        name  = "LOG_LEVEL"
+        value = "debug"
+      }
+      env {
+        name  = "AUTH0_DOMAIN"
+        value = var.auth0_domain
+      }
+      env {
+        name  = "AUTH0_AUDIENCE"
+        value = local.public_url
+      }
+      env {
+        name  = "CORS_ORIGIN"
+        value = local.public_url
+      }
+      env {
+        name  = "CORS_METHODS"
+        value = "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS"
+      }
+      env {
+        name  = "AUTH_ENABLED"
+        value = "true"
+      }
+      env {
+        name  = "PRISMA_LOG_LEVEL"
+        value = "query,info,warn,error"
+      }
+      env {
+        name = "DATABASE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.db_connection_string.secret_id
+            version = "latest"
+          }
+        }
+      }
+    }
+  }
+
+  # Cloud Build / Cloud Deploy で image を更新するため、image / scaling を ignore
+  # AWS の aws_ecs_service の lifecycle.ignore_changes (task_definition) と同じ思想
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+      client,
+      client_version,
+    ]
+  }
+
+  depends_on = [
+    google_project_iam_member.cloud_run_secret_accessor,
+    google_artifact_registry_repository_iam_member.cloud_run_ar_reader,
+  ]
+}
+
+# LB (Serverless NEG 経由) からの呼び出しのみを許可するため、Cloud Run の IAM Invoker を制御
+# 注: ingress=INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER により LB 経由のみアクセス可能 (AWS の VPC Origin 相当)
+# 公開トラフィックは LB → Cloud Run であり、Cloud Run に直接到達できないため allUsers Invoker は安全
+resource "google_cloud_run_v2_service_iam_member" "invoker" {
+  project  = google_cloud_run_v2_service.backend.project
+  location = google_cloud_run_v2_service.backend.location
+  name     = google_cloud_run_v2_service.backend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/iac/gcp/cloud_sql.tf
+++ b/iac/gcp/cloud_sql.tf
@@ -1,0 +1,102 @@
+# Cloud SQL for PostgreSQL: AWS の Aurora Serverless v2 相当
+# - Private IP のみ (Service Networking ピアリング経由)
+# - 自動バックアップ + PITR
+# - DB マスターパスワードはランダム生成、DATABASE_URL は Secret Manager に格納
+
+# DB マスターパスワード: 16桁ランダム
+resource "random_password" "db_password" {
+  length  = 16
+  special = false
+}
+
+# Cloud SQL インスタンス
+# Aurora Serverless v2 のような ACU 自動スケーリングはないが、
+# Cloud SQL のマシンタイプは variables.tf で調整可能
+resource "google_sql_database_instance" "main" {
+  name             = "${var.app-name}-${var.environment}-db"
+  region           = var.gcp-region
+  database_version = "POSTGRES_16"
+
+  deletion_protection = false
+
+  settings {
+    tier              = var.db-tier
+    availability_type = "ZONAL"
+    disk_type         = "PD_SSD"
+    disk_size         = 10
+    disk_autoresize   = true
+
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = google_compute_network.vpc.id
+      enable_private_path_for_google_cloud_services = true
+    }
+
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "17:00" # 02:00 JST (UTC-9)
+      point_in_time_recovery_enabled = true
+      transaction_log_retention_days = 7
+
+      backup_retention_settings {
+        retained_backups = 30
+        retention_unit   = "COUNT"
+      }
+    }
+
+    maintenance_window {
+      day          = 7 # Sunday
+      hour         = 18 # 03:00 JST
+      update_track = "stable"
+    }
+
+    insights_config {
+      query_insights_enabled  = true
+      query_string_length     = 1024
+      record_application_tags = false
+      record_client_address   = false
+    }
+
+    database_flags {
+      name  = "log_min_duration_statement"
+      value = "1000"
+    }
+  }
+
+  depends_on = [
+    google_service_networking_connection.psa,
+    google_project_service.services,
+  ]
+}
+
+# DB
+resource "google_sql_database" "app" {
+  name     = replace("${var.app-name}${var.environment}db", "-", "")
+  instance = google_sql_database_instance.main.name
+}
+
+# DB ユーザ
+resource "google_sql_user" "app" {
+  name     = replace("${var.app-name}${var.environment}dbadmin", "-", "")
+  instance = google_sql_database_instance.main.name
+  password = random_password.db_password.result
+}
+
+# DATABASE_URL を組み立て、Secret Manager に格納
+# (Cloud Run の env から secret_key_ref で参照する)
+locals {
+  db_encoded_password = urlencode(random_password.db_password.result)
+  database_url = join("", [
+    "postgresql://",
+    google_sql_user.app.name,
+    ":",
+    local.db_encoded_password,
+    "@",
+    google_sql_database_instance.main.private_ip_address,
+    ":5432/",
+    google_sql_database.app.name,
+    "?sslmode=require",
+    "&connection_limit=${var.db-connection-limit}",
+    "&pool_timeout=${var.db-pool-timeout}",
+  ])
+}

--- a/iac/gcp/cloud_storage.tf
+++ b/iac/gcp/cloud_storage.tf
@@ -1,0 +1,41 @@
+# 静的Webアセット配信用 Cloud Storage バケット (LB Backend Bucket 経由でのみ公開)
+# AWS の S3 バケット (web) 相当
+resource "google_storage_bucket" "web" {
+  name                        = "${var.app-name}-${var.environment}-web-${random_string.suffix.result}"
+  location                    = var.gcp-region
+  storage_class               = "STANDARD"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  # SPA ルーティング: 存在しないパスは index.html を返す
+  # AWS CloudFront の custom_error_response (403 → /index.html) と同等の挙動を実現
+  # Cloud CDN 経由でも notFoundPage が機能する
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "index.html"
+  }
+
+  # CORS は CloudFront 経由で API を叩く構成のため通常不要だが、
+  # フロントから直接 GCS にアクセスするケースに備えて空配列で明示
+  cors {
+    origin          = ["*"]
+    method          = ["GET", "HEAD"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+
+  versioning {
+    enabled = false
+  }
+}
+
+# Cloud CDN の LB がバケットを読むためのサービスアカウントに objectViewer を付与
+# (Backend Bucket は IAM 経由で参照するため、バケット ACL は不要)
+# 注: GCS Backend Bucket は自動的に Cloud CDN サービスアカウントからアクセスされる。
+# バケットが uniform_bucket_level_access の場合、明示的に Storage Object Viewer を付与する。
+resource "google_storage_bucket_iam_member" "web_cdn_viewer" {
+  bucket = google_storage_bucket.web.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:service-${data.google_project.self.number}@cloud-cdn-fill.iam.gserviceaccount.com"
+}

--- a/iac/gcp/firewall.tf
+++ b/iac/gcp/firewall.tf
@@ -1,0 +1,103 @@
+# GCP VPC Firewall ルール: AWS Security Group 相当
+# GCP の Firewall は VPC 単位で適用され、target tags / service accounts で対象を絞る
+#
+# AWS 側のルール構成:
+#   ALB SG       <- CloudFront VPC Origin                : 80
+#   ECS SG       <- ALB                                  : 3000
+#   ECS SG  egress -> 443 / DB SG                        : NAT + DB
+#   DB SG        <- ECS SG / Bastion                     : 5432
+#   Bastion SG   <- 開発者IP                              : 0-65535
+#   Bastion SG egress -> SSM endpoint / DB               : 443 / 5432
+#
+# GCP 側マッピング:
+#   - ALB + CloudFront 相当: External Application LB + Cloud CDN は VPC firewall の対象外
+#     (LB → Cloud Run は Serverless NEG 経由でマネージドネットワーク)
+#   - Cloud Run → Cloud SQL は Serverless VPC Access コネクタ経由
+#     コネクタ自身が source range として PSA range (Cloud SQL) へアクセスする
+#   - Bastion は IAP TCP forwarding 専用 (35.235.240.0/20 から SSH)
+#   - DB 接続は VPC Connector range / Bastion からのみ許可
+
+# 全 ingress をデフォルト拒否 (GCP のデフォルトと同じだが明示)
+# 不要トラフィックを遮断する保険として最低優先度で配置
+resource "google_compute_firewall" "deny_all_ingress" {
+  name      = "${var.app-name}-${var.environment}-deny-all-ingress"
+  network   = google_compute_network.vpc.name
+  direction = "INGRESS"
+  priority  = 65534
+
+  deny {
+    protocol = "all"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# Bastion への SSH を IAP TCP forwarding 経由でのみ許可
+# AWS の SSM Session Manager 相当 (踏み台への直接 SSH は不要)
+# IAP TCP forwarding の送信元 IP レンジは Google 固定の 35.235.240.0/20
+resource "google_compute_firewall" "bastion_ssh_from_iap" {
+  name      = "${var.app-name}-${var.environment}-bastion-ssh-from-iap"
+  network   = google_compute_network.vpc.name
+  direction = "INGRESS"
+  priority  = 1000
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = ["bastion"]
+}
+
+# Bastion からの egress: Cloud SQL Private IP (PSA range) への 5432 のみ
+# GCP の Firewall は egress も target tags ベースで制御可能
+resource "google_compute_firewall" "bastion_egress_db" {
+  name      = "${var.app-name}-${var.environment}-bastion-egress-db"
+  network   = google_compute_network.vpc.name
+  direction = "EGRESS"
+  priority  = 1000
+
+  allow {
+    protocol = "tcp"
+    ports    = ["5432"]
+  }
+
+  destination_ranges = [var.psa_range_cidr_block]
+  target_tags        = ["bastion"]
+}
+
+# Bastion からの egress: HTTPS (Cloud APIs / パッケージ更新)
+resource "google_compute_firewall" "bastion_egress_https" {
+  name      = "${var.app-name}-${var.environment}-bastion-egress-https"
+  network   = google_compute_network.vpc.name
+  direction = "EGRESS"
+  priority  = 1000
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  destination_ranges = ["0.0.0.0/0"]
+  target_tags        = ["bastion"]
+}
+
+# (任意) 開発者 PC IP からの 5432 直接接続を許可するルール
+# 通常は IAP TCP forwarding 経由で Bastion → DB を推奨するため無効化が望ましい
+resource "google_compute_firewall" "dev_pc_to_db" {
+  count     = length(var.local-pc-ip-addresses) > 0 ? 1 : 0
+  name      = "${var.app-name}-${var.environment}-devpc-to-db"
+  network   = google_compute_network.vpc.name
+  direction = "INGRESS"
+  priority  = 900
+
+  allow {
+    protocol = "tcp"
+    ports    = ["5432"]
+  }
+
+  source_ranges = var.local-pc-ip-addresses
+  # PSA range 内の Cloud SQL Private IP に届かせるため、target は指定せず PSA range 全体に到達可能とする
+  # 注意: 通常は不要。bastion を経由する運用を推奨
+}

--- a/iac/gcp/load_balancer.tf
+++ b/iac/gcp/load_balancer.tf
@@ -1,0 +1,250 @@
+# External Application Load Balancer + Cloud CDN
+# AWS の CloudFront + ALB + VPC Origin に相当
+#
+# 構成:
+#   ユーザ
+#     ↓
+#   Global Forwarding Rule (HTTPS 443 / HTTP 80→HTTPSリダイレクト)
+#     ↓
+#   Target HTTPS Proxy + Managed SSL Cert
+#     ↓
+#   URL Map (path matcher)
+#     ├── /api/*       → Backend Service (Serverless NEG → Cloud Run)
+#     └── default      → Backend Bucket  (GCS, Cloud CDN 有効)
+#                         └── SPAルーティング: notFoundPage = index.html
+#
+# Cloud Armor: HTTPS Backend Service / Backend Bucket にアタッチ
+#
+# AWS の /index.html 個別ビヘイビア (no-cache) に相当する仕組みは、
+# フロントエンドデプロイ時に index.html へ Cache-Control: no-store, no-cache を付与する運用で実現
+# (CloudFront 側と同じ手法)
+
+# グローバル静的 IP: LB のフロントエンド IP
+resource "google_compute_global_address" "lb_ip" {
+  name = "${var.app-name}-${var.environment}-lb-ip"
+}
+
+# Serverless NEG: Cloud Run サービスを LB のバックエンドとして公開する
+# Cloud Run サービスの実体は cloud_run.tf で定義
+resource "google_compute_region_network_endpoint_group" "backend_neg" {
+  name                  = "${var.app-name}-${var.environment}-backend-neg"
+  region                = var.gcp-region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.backend.name
+  }
+}
+
+# Backend Service: Cloud Run NEG をぶら下げる
+# AWS の ALB + Target Group + Cloud Armor (WAF) の組み合わせに相当
+resource "google_compute_backend_service" "backend" {
+  name                  = "${var.app-name}-${var.environment}-backend"
+  protocol              = "HTTPS"
+  port_name             = "http"
+  timeout_sec           = 30
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  security_policy       = google_compute_security_policy.edge.id
+  enable_cdn            = false
+
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+
+  backend {
+    group = google_compute_region_network_endpoint_group.backend_neg.id
+  }
+}
+
+# Backend Bucket: フロントエンド静的アセット用 (Cloud CDN 有効)
+# AWS の CloudFront default behavior (S3) 相当
+resource "google_compute_backend_bucket" "frontend" {
+  name        = "${var.app-name}-${var.environment}-frontend"
+  bucket_name = google_storage_bucket.web.name
+  enable_cdn  = true
+
+  cdn_policy {
+    # USE_ORIGIN_HEADERS: GCS にアップロード時に設定した Cache-Control をそのまま尊重
+    # index.html に Cache-Control: no-store, no-cache を付与してアップロードする運用で
+    # AWS の Managed-CachingDisabled (index.html ビヘイビア) と同等の挙動を実現
+    cache_mode  = "USE_ORIGIN_HEADERS"
+    client_ttl  = 86400
+    default_ttl = 86400
+    max_ttl     = 31536000
+
+    negative_caching = true
+    negative_caching_policy {
+      code = 404
+      ttl  = 10
+    }
+    negative_caching_policy {
+      code = 403
+      ttl  = 10
+    }
+  }
+
+  edge_security_policy = google_compute_security_policy.edge.id
+}
+
+# URL Map: パスルーティング + セキュリティヘッダ付与
+# - /api/*  → Backend Service (Cloud Run)
+# - default → Backend Bucket (GCS)
+resource "google_compute_url_map" "main" {
+  name            = "${var.app-name}-${var.environment}-urlmap"
+  default_service = google_compute_backend_bucket.frontend.id
+
+  # SPA 配信時のセキュリティヘッダ (AWS cloudfront_response_headers_policy.spa 相当)
+  default_route_action {
+    cors_policy {
+      allow_origins   = ["*"]
+      allow_methods   = ["GET", "HEAD", "OPTIONS"]
+      max_age         = 3600
+      disabled        = false
+    }
+  }
+
+  header_action {
+    response_headers_to_add {
+      header_name  = "Strict-Transport-Security"
+      header_value = "max-age=31536000; includeSubDomains"
+      replace      = true
+    }
+    response_headers_to_add {
+      header_name  = "X-Content-Type-Options"
+      header_value = "nosniff"
+      replace      = true
+    }
+    response_headers_to_add {
+      header_name  = "X-Frame-Options"
+      header_value = "DENY"
+      replace      = true
+    }
+    response_headers_to_add {
+      header_name  = "Referrer-Policy"
+      header_value = "strict-origin-when-cross-origin"
+      replace      = true
+    }
+    response_headers_to_add {
+      header_name  = "X-XSS-Protection"
+      header_value = "0"
+      replace      = true
+    }
+    response_headers_to_add {
+      header_name  = "Permissions-Policy"
+      header_value = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+      replace      = true
+    }
+    response_headers_to_add {
+      header_name = "Content-Security-Policy"
+      header_value = join("; ", [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: https:",
+        "font-src 'self' data:",
+        "connect-src 'self' https://${var.auth0_domain}",
+        "frame-src https://${var.auth0_domain}",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "frame-ancestors 'none'",
+        "upgrade-insecure-requests",
+      ])
+      replace = true
+    }
+  }
+
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "main"
+  }
+
+  path_matcher {
+    name            = "main"
+    default_service = google_compute_backend_bucket.frontend.id
+
+    # /api/* → Cloud Run (セキュリティヘッダは backend 側の方針に従い API 用は最小限)
+    path_rule {
+      paths   = ["/api", "/api/*"]
+      service = google_compute_backend_service.backend.id
+
+      route_action {
+        # API には CSP / Permissions-Policy を付与しない (AWS の api ポリシーと整合)
+        cors_policy {
+          allow_origins        = ["*"]
+          allow_methods        = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
+          allow_headers        = ["*"]
+          max_age              = 3600
+          disabled             = false
+        }
+      }
+    }
+  }
+}
+
+# HTTPS 用 URL Map: 上記をそのまま利用
+# HTTP → HTTPS リダイレクト用 URL Map: 別途定義
+resource "google_compute_url_map" "https_redirect" {
+  name = "${var.app-name}-${var.environment}-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
+# Google マネージド SSL 証明書
+# 注: グローバル LB IP に対する DNS A レコードを別途設定し、ドメイン所有を証明する必要あり
+# 本テンプレートでは LB IP 直叩きでも動作するよう、self-managed/managed 両対応のフラグを変数化することも可能
+# ここでは最小構成として LB IP 用に self-signed の HTTPS は省略し、HTTPS は managed cert + ドメインを前提とする
+resource "google_compute_managed_ssl_certificate" "main" {
+  count = var.lb-domain == "" ? 0 : 1
+  name  = "${var.app-name}-${var.environment}-cert"
+
+  managed {
+    domains = [var.lb-domain]
+  }
+}
+
+# Target HTTPS Proxy
+resource "google_compute_target_https_proxy" "main" {
+  count            = var.lb-domain == "" ? 0 : 1
+  name             = "${var.app-name}-${var.environment}-https-proxy"
+  url_map          = google_compute_url_map.main.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.main[0].id]
+}
+
+# Target HTTP Proxy (リダイレクト用)
+resource "google_compute_target_http_proxy" "main_redirect" {
+  count   = var.lb-domain == "" ? 0 : 1
+  name    = "${var.app-name}-${var.environment}-http-redirect"
+  url_map = google_compute_url_map.https_redirect.id
+}
+
+# ドメインが未設定の場合は HTTP のみで動作確認できるようにする (PoC 用)
+resource "google_compute_target_http_proxy" "main_http_only" {
+  count   = var.lb-domain == "" ? 1 : 0
+  name    = "${var.app-name}-${var.environment}-http-proxy"
+  url_map = google_compute_url_map.main.id
+}
+
+# Global Forwarding Rule: HTTPS:443
+resource "google_compute_global_forwarding_rule" "https" {
+  count                 = var.lb-domain == "" ? 0 : 1
+  name                  = "${var.app-name}-${var.environment}-https"
+  ip_address            = google_compute_global_address.lb_ip.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  target                = google_compute_target_https_proxy.main[0].id
+}
+
+# Global Forwarding Rule: HTTP:80 (HTTPS リダイレクト用 / ドメイン未設定時は通常応答)
+resource "google_compute_global_forwarding_rule" "http" {
+  name                  = "${var.app-name}-${var.environment}-http"
+  ip_address            = google_compute_global_address.lb_ip.address
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  target                = var.lb-domain == "" ? google_compute_target_http_proxy.main_http_only[0].id : google_compute_target_http_proxy.main_redirect[0].id
+}

--- a/iac/gcp/monitoring_alerts.tf
+++ b/iac/gcp/monitoring_alerts.tf
@@ -1,0 +1,234 @@
+# Cloud Monitoring アラートポリシー: AWS CloudWatch Alarms 相当
+#
+# 通知先: Pub/Sub トピック + Email チャネル (variables.tf の alert-notification-emails 使用)
+# サブスクリプション (Slack/Lambda等) は Terraform 外で管理する想定 (AWS と同じ思想)
+#
+# 閾値マッピング (AWS 側 cloudwatch_alarms.tf と整合):
+#   Cloud Run CPU使用率        > 80%
+#   Cloud Run メモリ使用率     > 80%
+#   Cloud SQL CPU使用率        > 80%
+#   Cloud SQL コネクション数   > 70 (db-custom-1-3840 で最大100に対する警告)
+#   Cloud SQL メモリ使用率     > 80%
+#   Cloud SQL ディスク使用率   > 80%
+#   Cloud SQL ディスク容量     > 100 GiB (コスト監視)
+
+locals {
+  alarm_eval_duration            = "120s" # 連続2回(60秒×2)を超えたら通知
+  alarm_period                   = "60s"  # 評価間隔
+  alarm_cpu_threshold_pct        = 0.8    # Cloud Run / Cloud SQL CPU 80%
+  alarm_memory_util_pct          = 0.8
+  alarm_disk_util_pct            = 0.8
+  alarm_db_connections_threshold = 70
+  alarm_db_volume_bytes          = 107374182400 # 100 GiB
+}
+
+# 全アラーム共通の通知先 Pub/Sub トピック (Terraform 外でサブスクリプションを管理)
+resource "google_pubsub_topic" "alarms" {
+  name = "${var.app-name}-${var.environment}-alarms"
+
+  depends_on = [google_project_service.services]
+}
+
+# Pub/Sub 通知チャネル
+resource "google_monitoring_notification_channel" "pubsub" {
+  display_name = "${var.app-name}-${var.environment}-alarms-pubsub"
+  type         = "pubsub"
+
+  labels = {
+    topic = google_pubsub_topic.alarms.id
+  }
+
+  user_labels = {
+    app         = var.app-name
+    environment = var.environment
+  }
+
+  depends_on = [google_pubsub_topic_iam_member.monitoring_publisher]
+}
+
+# Cloud Monitoring が Pub/Sub に publish するための IAM 付与
+resource "google_pubsub_topic_iam_member" "monitoring_publisher" {
+  topic  = google_pubsub_topic.alarms.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.self.number}@gcp-sa-monitoring-notification.iam.gserviceaccount.com"
+}
+
+# Email 通知チャネル (alert-notification-emails が設定されている場合のみ)
+resource "google_monitoring_notification_channel" "email" {
+  for_each     = toset(var.alert-notification-emails)
+  display_name = "${var.app-name}-${var.environment}-email-${replace(each.value, "@", "-at-")}"
+  type         = "email"
+
+  labels = {
+    email_address = each.value
+  }
+}
+
+locals {
+  notification_channels = concat(
+    [google_monitoring_notification_channel.pubsub.id],
+    [for ch in google_monitoring_notification_channel.email : ch.id],
+  )
+}
+
+# ---------- Cloud Run ----------
+
+resource "google_monitoring_alert_policy" "cloud_run_cpu_high" {
+  display_name = "${var.app-name}-${var.environment}-run-cpu-high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud Run CPU > 80%"
+    condition_threshold {
+      filter          = "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = \"${google_cloud_run_v2_service.backend.name}\" AND metric.type = \"run.googleapis.com/container/cpu/utilizations\""
+      duration        = local.alarm_eval_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.alarm_cpu_threshold_pct
+
+      aggregations {
+        alignment_period   = local.alarm_period
+        per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = local.notification_channels
+  user_labels = {
+    app         = var.app-name
+    environment = var.environment
+  }
+}
+
+resource "google_monitoring_alert_policy" "cloud_run_memory_high" {
+  display_name = "${var.app-name}-${var.environment}-run-memory-high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud Run memory > 80%"
+    condition_threshold {
+      filter          = "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = \"${google_cloud_run_v2_service.backend.name}\" AND metric.type = \"run.googleapis.com/container/memory/utilizations\""
+      duration        = local.alarm_eval_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.alarm_memory_util_pct
+
+      aggregations {
+        alignment_period   = local.alarm_period
+        per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = local.notification_channels
+}
+
+# ---------- Cloud SQL ----------
+
+resource "google_monitoring_alert_policy" "sql_cpu_high" {
+  display_name = "${var.app-name}-${var.environment}-sql-cpu-high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL CPU > 80%"
+    condition_threshold {
+      filter          = "resource.type = \"cloudsql_database\" AND resource.labels.database_id = \"${var.gcp-project-id}:${google_sql_database_instance.main.name}\" AND metric.type = \"cloudsql.googleapis.com/database/cpu/utilization\""
+      duration        = local.alarm_eval_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.alarm_cpu_threshold_pct
+
+      aggregations {
+        alignment_period   = local.alarm_period
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  notification_channels = local.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "sql_memory_high" {
+  display_name = "${var.app-name}-${var.environment}-sql-memory-high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL memory > 80%"
+    condition_threshold {
+      filter          = "resource.type = \"cloudsql_database\" AND resource.labels.database_id = \"${var.gcp-project-id}:${google_sql_database_instance.main.name}\" AND metric.type = \"cloudsql.googleapis.com/database/memory/utilization\""
+      duration        = local.alarm_eval_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.alarm_memory_util_pct
+
+      aggregations {
+        alignment_period   = local.alarm_period
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  notification_channels = local.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "sql_connections_high" {
+  display_name = "${var.app-name}-${var.environment}-sql-connections-high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL connections > ${local.alarm_db_connections_threshold}"
+    condition_threshold {
+      filter          = "resource.type = \"cloudsql_database\" AND resource.labels.database_id = \"${var.gcp-project-id}:${google_sql_database_instance.main.name}\" AND metric.type = \"cloudsql.googleapis.com/database/postgresql/num_backends\""
+      duration        = local.alarm_eval_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.alarm_db_connections_threshold
+
+      aggregations {
+        alignment_period   = local.alarm_period
+        per_series_aligner = "ALIGN_MAX"
+      }
+    }
+  }
+
+  notification_channels = local.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "sql_disk_high" {
+  display_name = "${var.app-name}-${var.environment}-sql-disk-high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL disk utilization > 80%"
+    condition_threshold {
+      filter          = "resource.type = \"cloudsql_database\" AND resource.labels.database_id = \"${var.gcp-project-id}:${google_sql_database_instance.main.name}\" AND metric.type = \"cloudsql.googleapis.com/database/disk/utilization\""
+      duration        = local.alarm_eval_duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.alarm_disk_util_pct
+
+      aggregations {
+        alignment_period   = local.alarm_period
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  notification_channels = local.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "sql_disk_bytes_high" {
+  display_name = "${var.app-name}-${var.environment}-sql-disk-bytes-high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud SQL disk bytes > 100 GiB"
+    condition_threshold {
+      filter          = "resource.type = \"cloudsql_database\" AND resource.labels.database_id = \"${var.gcp-project-id}:${google_sql_database_instance.main.name}\" AND metric.type = \"cloudsql.googleapis.com/database/disk/bytes_used\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.alarm_db_volume_bytes
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_MAX"
+      }
+    }
+  }
+
+  notification_channels = local.notification_channels
+}

--- a/iac/gcp/provider.tf
+++ b/iac/gcp/provider.tf
@@ -1,0 +1,47 @@
+# Google Cloud プロバイダ: 東京リージョン(asia-northeast1)を既定とする
+# プロジェクト/リージョンは terraform.tfvars で指定
+provider "google" {
+  project = var.gcp-project-id
+  region  = var.gcp-region
+}
+
+# google-beta プロバイダ: Cloud Run の一部機能 / Cloud Armor の adaptive protection 等で必要
+provider "google-beta" {
+  project = var.gcp-project-id
+  region  = var.gcp-region
+}
+
+# Auth0プロバイダ: テナント情報を環境変数(terraform.tfvars)から注入
+provider "auth0" {
+  domain        = var.auth0_domain
+  client_id     = var.auth0_client_id
+  client_secret = var.auth0_client_secret
+}
+
+# Terraform本体とプロバイダのバージョン固定 (AWS/Azure 側と整合)
+terraform {
+  required_version = ">= 1.13.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.0.0"
+    }
+    auth0 = {
+      source  = "auth0/auth0"
+      version = "1.33.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6.0"
+    }
+  }
+}
+
+# 現在のプロジェクト情報 (project number 等を参照する箇所がある)
+data "google_project" "self" {
+  project_id = var.gcp-project-id
+}

--- a/iac/gcp/secret_manager.tf
+++ b/iac/gcp/secret_manager.tf
@@ -1,0 +1,20 @@
+# Secret Manager: AWS の SSM Parameter Store (SecureString) 相当
+# DATABASE_URL を格納し、Cloud Run の env から参照する。
+resource "google_secret_manager_secret" "db_connection_string" {
+  secret_id = "${var.app-name}-${var.environment}-database-url"
+
+  replication {
+    user_managed {
+      replicas {
+        location = var.gcp-region
+      }
+    }
+  }
+
+  depends_on = [google_project_service.services]
+}
+
+resource "google_secret_manager_secret_version" "db_connection_string" {
+  secret      = google_secret_manager_secret.db_connection_string.id
+  secret_data = local.database_url
+}

--- a/iac/gcp/start-stop-resources.tf
+++ b/iac/gcp/start-stop-resources.tf
@@ -1,0 +1,188 @@
+# 自動起動・停止: AWS の EventBridge Scheduler + Step Functions 相当
+# - Cloud Scheduler: cron トリガー (Asia/Tokyo)
+# - Cloud Workflows: 複数 GCP API を順次/並列で実行
+#
+# Auto-stop  : 毎日 13:00 JST (デフォルト有効)
+#   1. Cloud Run min/max インスタンスを 0 にする (= 実質停止)
+#   2. Cloud SQL インスタンスを停止
+#   3. Bastion VM を停止
+#
+# Auto-start : 土日 5:00 JST (デフォルト無効 = paused)
+#   1. Bastion VM を起動
+#   2. Cloud SQL インスタンスを起動 → 起動完了まで待機
+#   3. Cloud Run min/max インスタンスを 1 に戻す
+
+# Workflows 実行用 SA
+resource "google_service_account" "workflows" {
+  account_id   = "${var.app-name}-${var.environment}-workflows"
+  display_name = "Workflows SA for auto start/stop"
+}
+
+# Workflows SA に必要な権限を付与
+# - Cloud SQL Admin: インスタンス起動/停止
+# - Compute Instance Admin (v1): Bastion VM 起動/停止
+# - Cloud Run Admin: Cloud Run サービスの scaling 更新
+resource "google_project_iam_member" "workflows_sql_admin" {
+  project = var.gcp-project-id
+  role    = "roles/cloudsql.admin"
+  member  = "serviceAccount:${google_service_account.workflows.email}"
+}
+
+resource "google_project_iam_member" "workflows_compute_admin" {
+  project = var.gcp-project-id
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.workflows.email}"
+}
+
+resource "google_project_iam_member" "workflows_run_admin" {
+  project = var.gcp-project-id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.workflows.email}"
+}
+
+# Workflows 自身が他の SA (cloud_run SA) をなくしては Cloud Run 更新できない場合があるため
+# Service Account User も付与
+resource "google_project_iam_member" "workflows_sa_user" {
+  project = var.gcp-project-id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.workflows.email}"
+}
+
+# Auto-stop ワークフロー
+resource "google_workflows_workflow" "auto_stop" {
+  name            = "${var.app-name}-${var.environment}-auto-stop"
+  region          = var.gcp-region
+  service_account = google_service_account.workflows.id
+
+  source_contents = <<-EOT
+    main:
+      steps:
+        - scale_run_to_zero:
+            call: http.patch
+            args:
+              url: $${"https://run.googleapis.com/v2/projects/${var.gcp-project-id}/locations/${var.gcp-region}/services/${google_cloud_run_v2_service.backend.name}?updateMask=template.scaling"}
+              auth:
+                type: OAuth2
+              body:
+                template:
+                  scaling:
+                    minInstanceCount: 0
+                    maxInstanceCount: 0
+        - stop_sql:
+            call: http.patch
+            args:
+              url: $${"https://sqladmin.googleapis.com/v1/projects/${var.gcp-project-id}/instances/${google_sql_database_instance.main.name}"}
+              auth:
+                type: OAuth2
+              body:
+                settings:
+                  activationPolicy: NEVER
+        - stop_bastion:
+            call: googleapis.compute.v1.instances.stop
+            args:
+              project: ${var.gcp-project-id}
+              zone: ${var.gcp-zone}
+              instance: ${google_compute_instance.bastion.name}
+        - done:
+            return: "auto-stop completed"
+  EOT
+
+  depends_on = [google_project_service.services]
+}
+
+# Auto-start ワークフロー
+resource "google_workflows_workflow" "auto_start" {
+  name            = "${var.app-name}-${var.environment}-auto-start"
+  region          = var.gcp-region
+  service_account = google_service_account.workflows.id
+
+  source_contents = <<-EOT
+    main:
+      steps:
+        - start_bastion:
+            call: googleapis.compute.v1.instances.start
+            args:
+              project: ${var.gcp-project-id}
+              zone: ${var.gcp-zone}
+              instance: ${google_compute_instance.bastion.name}
+        - start_sql:
+            call: http.patch
+            args:
+              url: $${"https://sqladmin.googleapis.com/v1/projects/${var.gcp-project-id}/instances/${google_sql_database_instance.main.name}"}
+              auth:
+                type: OAuth2
+              body:
+                settings:
+                  activationPolicy: ALWAYS
+        - wait_for_sql:
+            call: sys.sleep
+            args:
+              seconds: 720
+        - scale_run_back:
+            call: http.patch
+            args:
+              url: $${"https://run.googleapis.com/v2/projects/${var.gcp-project-id}/locations/${var.gcp-region}/services/${google_cloud_run_v2_service.backend.name}?updateMask=template.scaling"}
+              auth:
+                type: OAuth2
+              body:
+                template:
+                  scaling:
+                    minInstanceCount: 0
+                    maxInstanceCount: 10
+        - done:
+            return: "auto-start completed"
+  EOT
+}
+
+# Cloud Scheduler 用 SA (Workflows を起動できる)
+resource "google_service_account" "scheduler" {
+  account_id   = "${var.app-name}-${var.environment}-scheduler"
+  display_name = "Cloud Scheduler SA for workflow trigger"
+}
+
+resource "google_project_iam_member" "scheduler_workflow_invoker" {
+  project = var.gcp-project-id
+  role    = "roles/workflows.invoker"
+  member  = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+# Auto-stop スケジューラ: 毎日 13:00 JST = UTC 04:00
+resource "google_cloud_scheduler_job" "auto_stop" {
+  name      = "${var.app-name}-${var.environment}-auto-stop"
+  region    = var.gcp-region
+  schedule  = "0 13 * * *"
+  time_zone = "Asia/Tokyo"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.auto_stop.id}/executions"
+    body        = base64encode("{}")
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_iam_member.scheduler_workflow_invoker]
+}
+
+# Auto-start スケジューラ: 土日 5:00 JST、デフォルトは paused (= AWS の DISABLED 相当)
+resource "google_cloud_scheduler_job" "auto_start" {
+  name      = "${var.app-name}-${var.environment}-auto-start"
+  region    = var.gcp-region
+  schedule  = "0 5 * * 6,0"
+  time_zone = "Asia/Tokyo"
+  paused    = true
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.auto_start.id}/executions"
+    body        = base64encode("{}")
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_iam_member.scheduler_workflow_invoker]
+}

--- a/iac/gcp/variables.tf
+++ b/iac/gcp/variables.tf
@@ -1,0 +1,154 @@
+## 環境変数で指定する。terraform.tfvars に記載
+variable "auth0_domain" {
+  description = "【環境変数で指定】認証用アプリケーションのDomain"
+}
+variable "auth0_client_id" {
+  description = "【環境変数で指定】認証用アプリケーションのClient ID"
+}
+variable "auth0_client_secret" {
+  description = "【環境変数で指定】認証用アプリケーションのClient Secrets"
+}
+
+variable "github-repository-name" {
+  description = "【環境変数で指定】GitHubリポジトリ名 (owner/repo 形式)"
+}
+
+variable "github-owner" {
+  description = "GitHub Owner 名 (Cloud Build GitHub 連携で使用)"
+}
+
+# Cloud Build の GitHub 連携 (Cloud Build GitHub App) を事前に承認した後の Connection ID
+# 例: projects/PROJECT_ID/locations/REGION/connections/github
+variable "cloudbuild-github-connection" {
+  description = "【環境変数で指定】Cloud Build GitHub Connection リソース名"
+  default     = ""
+}
+
+## GCPプロジェクトとリージョン
+variable "gcp-project-id" {
+  description = "【環境変数で指定】GCP プロジェクト ID"
+}
+
+variable "gcp-region" {
+  default     = "asia-northeast1"
+  description = "GCP リージョン (東京)"
+}
+
+variable "gcp-zone" {
+  default     = "asia-northeast1-a"
+  description = "GCP ゾーン (Bastion VM 配置先)"
+}
+
+## アプリ名と環境(各リソース名のプレフィックスとして利用)
+variable "app-name" {
+  default = "sandbox-gcp"
+}
+
+variable "environment" {
+  default = "dev"
+}
+
+variable "frontend-src-root" {
+  default     = "frontend/sandbox-frontend"
+  description = "frontendのルートパス"
+}
+
+variable "backend-src-root" {
+  default     = "backend/sandbox-backend"
+  description = "backendのルートパス"
+}
+
+variable "target-branch" {
+  default     = "main"
+  description = "このブランチにPushされたときにCloud Buildをトリガー"
+}
+
+## Cloud Storage のバケット名をユニークにするための乱数(グローバル一意制約への対応)
+resource "random_string" "suffix" {
+  length  = 5
+  upper   = false
+  lower   = true
+  numeric = true
+  special = false
+}
+
+# VPC に割り当てる主サブネット CIDR
+variable "subnet_primary_cidr_block" {
+  default     = "172.16.2.0/24"
+  description = "Cloud Run コネクタ / Bastion / Cloud SQL 用プライマリサブネット"
+}
+
+# Serverless VPC Access コネクタ用サブネット (/28 必須)
+variable "subnet_connector_cidr_block" {
+  default     = "172.16.4.0/28"
+  description = "Serverless VPC Access コネクタ専用 /28 サブネット"
+}
+
+# Cloud SQL Private Service Access 用予約レンジ
+variable "psa_range_cidr_block" {
+  default     = "172.16.16.0/20"
+  description = "Cloud SQL / Memorystore 等の Private Service Access 用予約 IP レンジ (/16-/24)"
+}
+
+variable "api-base-path" {
+  default     = "/api/*"
+  description = "backendのbase-path。このpathが増える場合は、URL マップに追加する"
+}
+
+variable "health-check-path" {
+  default     = "/health"
+  description = "backend側で作ったヘルスチェックのエンドポイント"
+}
+
+variable "api-expose-port" {
+  type        = number
+  default     = 3000
+  description = "DockerfileでEXPOSEしているポートを指定 (Cloud Run コンテナポート)"
+}
+
+variable "local-pc-ip-addresses" {
+  type        = list(string)
+  default     = []
+  description = "接続元のIPアドレス (Bastion 用 IAP では不要だが、参考のため AWS と揃える)"
+}
+
+# Prismaコネクションプール設定 (AWS と同じ指針)
+# 設定指針: Cloud Run 最大インスタンス数 × db-connection-limit ≦ Cloud SQL 最大コネクション数 × 0.8
+# Cloud SQL の最大コネクションはマシンタイプで決まる (db-f1-micro: 25 / db-custom-1-3840: 100 / db-custom-2-7680: 200 etc.)
+variable "db-connection-limit" {
+  type        = number
+  default     = 5
+  description = "Prismaが1プロセスで保持するコネクション数の上限"
+}
+
+variable "db-pool-timeout" {
+  type        = number
+  default     = 15
+  description = "Prismaのコネクションプール空き待ちタイムアウト(秒)"
+}
+
+# Cloud SQL のマシンタイプ (最小構成の例)
+variable "db-tier" {
+  default     = "db-custom-1-3840"
+  description = "Cloud SQL マシンタイプ"
+}
+
+# 監視アラート通知先 (Pub/Sub topic のサブスクライブは Terraform 外で管理)
+variable "alert-notification-emails" {
+  type        = list(string)
+  default     = []
+  description = "Cloud Monitoring アラート通知先 email (空の場合は通知チャネル未作成)"
+}
+
+# 公開ドメイン (Managed SSL 証明書 + HTTPS リダイレクトに使用)
+# 空文字の場合は HTTP のみで LB を構成 (PoC 用)
+variable "lb-domain" {
+  default     = ""
+  description = "External Application LB の公開ドメイン名 (例: app.example.com)。設定すると Managed SSL 証明書を作成し HTTPS リダイレクトを有効化"
+}
+
+# Cloud Run / フロントから参照する公開 URL
+# ドメイン未設定時は http://<LB-IP>、設定時は https://<lb-domain>
+locals {
+  public_url = var.lb-domain == "" ? "http://${google_compute_global_address.lb_ip.address}" : "https://${var.lb-domain}"
+}

--- a/iac/gcp/vpc.tf
+++ b/iac/gcp/vpc.tf
@@ -1,0 +1,124 @@
+# GCP プロジェクトで利用する API を有効化
+# AWS では暗黙的に有効だが、GCP では事前有効化が必須
+resource "google_project_service" "services" {
+  for_each = toset([
+    "compute.googleapis.com",
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "sqladmin.googleapis.com",
+    "secretmanager.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "clouddeploy.googleapis.com",
+    "iap.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "workflows.googleapis.com",
+    "monitoring.googleapis.com",
+    "logging.googleapis.com",
+    "pubsub.googleapis.com",
+    "bigquery.googleapis.com",
+    "cloudkms.googleapis.com",
+  ])
+  service                    = each.value
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+# アプリ全体を収容する VPC (auto subnet を無効化して明示的にサブネットを定義)
+resource "google_compute_network" "vpc" {
+  name                            = "${var.app-name}-${var.environment}"
+  auto_create_subnetworks         = false
+  routing_mode                    = "REGIONAL"
+  delete_default_routes_on_create = false
+
+  depends_on = [google_project_service.services]
+}
+
+# プライマリサブネット: Bastion 等のリソース配置先
+# Private Google Access を有効化することで NAT 経由せず GCP API に到達できる
+# (AWS の VPC Endpoint 相当)
+resource "google_compute_subnetwork" "primary" {
+  name                     = "${var.app-name}-${var.environment}-primary"
+  ip_cidr_range            = var.subnet_primary_cidr_block
+  region                   = var.gcp-region
+  network                  = google_compute_network.vpc.id
+  private_ip_google_access = true
+
+  # VPC Flow Logs: AWS の VPC Flow Logs 相当 (Cloud Logging へ出力)
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Serverless VPC Access コネクタ用サブネット (/28 必須・コネクタ専用)
+resource "google_compute_subnetwork" "connector" {
+  name                     = "${var.app-name}-${var.environment}-connector"
+  ip_cidr_range            = var.subnet_connector_cidr_block
+  region                   = var.gcp-region
+  network                  = google_compute_network.vpc.id
+  private_ip_google_access = true
+}
+
+# Cloud Router: Cloud NAT のための論理ルータ
+resource "google_compute_router" "nat" {
+  name    = "${var.app-name}-${var.environment}-router"
+  region  = var.gcp-region
+  network = google_compute_network.vpc.id
+}
+
+# Cloud NAT: AWS の Regional NAT Gateway 相当
+# - VPC 内インスタンスのアウトバウンドインターネット通信を NAT
+# - IP は自動払い出し
+resource "google_compute_router_nat" "nat" {
+  name                               = "${var.app-name}-${var.environment}-nat"
+  router                             = google_compute_router.nat.name
+  region                             = var.gcp-region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
+# Serverless VPC Access コネクタ: Cloud Run → VPC へのトラフィックを通す
+# AWS の ECS Fargate awsvpc モード相当 (Cloud SQL Private IP に到達するため)
+resource "google_vpc_access_connector" "connector" {
+  name          = "${var.app-name}-${var.environment}"
+  region        = var.gcp-region
+  subnet {
+    name = google_compute_subnetwork.connector.name
+  }
+  machine_type   = "e2-micro"
+  min_instances  = 2
+  max_instances  = 3
+  max_throughput = 300
+
+  depends_on = [google_project_service.services]
+}
+
+# Private Service Access 用 IP レンジ予約
+# Cloud SQL Private IP 接続に必要 (Google マネージドプロデューササービスへの VPC ピアリングで利用)
+resource "google_compute_global_address" "psa_range" {
+  name          = "${var.app-name}-${var.environment}-psa-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = tonumber(split("/", var.psa_range_cidr_block)[1])
+  address       = split("/", var.psa_range_cidr_block)[0]
+  network       = google_compute_network.vpc.id
+}
+
+# Service Networking 接続: Cloud SQL 等のマネージドサービスを Private IP で使うためのピアリング
+resource "google_service_networking_connection" "psa" {
+  network                 = google_compute_network.vpc.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.psa_range.name]
+
+  depends_on = [google_project_service.services]
+}


### PR DESCRIPTION
## Summary

- `iac/gcp/` を新規追加し、AWS 側 (`iac/aws/`) と同等のクラウドインフラを Terraform で定義
- `docs/iac-spec.md` に GCP セクション (§5) を追加し、対応表・変数・デプロイ手順・セキュリティ表を 3 クラウド対応へ更新
- 採用構成: Cloud Run + Cloud SQL for PostgreSQL + Cloud Build + Cloud Deploy

## 主要マッピング (AWS → GCP)

| AWS | GCP |
|---|---|
| CloudFront + WAF v2 | External Application LB + Cloud CDN + Cloud Armor |
| S3 (frontend) | Cloud Storage (`notFoundPage = index.html` で SPA ルーティング) |
| ECS Fargate + ALB | Cloud Run v2 (Serverless NEG / `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`) |
| Aurora Serverless v2 | Cloud SQL for PostgreSQL (Private IP / PSA) |
| SSM Parameter Store | Secret Manager |
| ECR | Artifact Registry |
| EC2 Bastion + SSM | Compute Engine + IAP TCP forwarding |
| CodePipeline | Cloud Build (build/push) + Cloud Deploy (rollout) |
| CloudWatch Alarms + SNS | Cloud Monitoring + Pub/Sub + Email |
| Athena (Glue Catalog) | BigQuery (Logging sink, 4 データセット) |
| EventBridge Scheduler + Step Functions | Cloud Scheduler + Cloud Workflows |

## 設計上の判断

- **SPA ルーティング**: GCS の `notFoundPage` で 404 → index.html (CloudFront の `custom_error_response` 相当)
- **`index.html` no-cache**: Cloud CDN `USE_ORIGIN_HEADERS` + デプロイ時に `Cache-Control: no-store, no-cache` を付与 (AWS と同じ運用)
- **Cloud Armor**: preconfigured WAF (sqli/xss/lfi/rce/protocolattack/scannerdetection) + Adaptive Protection + `/api/*` レート制限 2000req/5min/IP
- **Bastion**: パブリック IP なし、IAP TCP forwarding 経由 SSH のみ (35.235.240.0/20)
- **CI/CD**: Cloud Build (build/push) → Cloud Deploy (rollout) で AWS CodePipeline の Build/Deploy 分離を再現
- **ログ分析**: Logging sink で BigQuery へエクスポート (Glue RegexSerDe / partition projection 不要)

## 事前準備 (`terraform apply` 前に必要)

1. `gcloud auth application-default login` で ADC を設定
2. Cloud Build GitHub App を Cloud Console から承認し、2nd gen Repository Connection を作成
3. `cloudbuild-github-connection` に Connection リソース名を設定 (例: `projects/PROJECT/locations/asia-northeast1/connections/github`)
4. バックエンド配下に `skaffold.yaml` + Cloud Run manifest を配置 (Cloud Deploy `cloud-run` ターゲット要件)
5. `iac/gcp/terraform.tfvars` を編集 (gitignore 済み)

## Test plan

- [ ] `iac/gcp/` で `terraform init && terraform validate` がエラーなく完了する
- [ ] `terraform plan` で全リソースが Create 計画になる (drift なし)
- [ ] `terraform apply` 後、LB IP に HTTP アクセスして SPA が表示される
- [ ] `/api/health` が Cloud Run 経由で 200 を返す
- [ ] Bastion へ IAP TCP forwarding で SSH 可能 (`gcloud compute ssh --tunnel-through-iap`)
- [ ] Bastion 経由で psql で Cloud SQL に接続できる
- [ ] Cloud Build トリガーが GitHub push で発火する (backend / frontend それぞれ)
- [ ] Cloud Armor ログ・LB アクセスログ・Cloud Run ログが BigQuery にエクスポートされる
- [ ] Cloud Scheduler の auto-stop ワークフローが手動実行で正常に完走する

🤖 Generated with [Claude Code](https://claude.com/claude-code)