### PR TITLE
fix(gcp): VPC コネクタの max_throughput を削除 (max_instances と排他)

### DIFF
--- a/iac/gcp/.terraform.lock.hcl
+++ b/iac/gcp/.terraform.lock.hcl
@@ -1,0 +1,85 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/auth0/auth0" {
+  version     = "1.33.0"
+  constraints = "1.33.0"
+  hashes = [
+    "h1:bxFsOL616TNoFBS+qvcajQKlg752+siYUx1HZOKNk8c=",
+    "zh:16e9d97043bf779de631cd1365cd549d854bfd70bf7f2c740b45e27bdf50956d",
+    "zh:3e80bc1197359f0556ebfdee71126cc3b0b2c39ac7b910e80ef6f16da83ee524",
+    "zh:50844666640d33a3ef57f9eba96c61d76924f908b448b8d4ccb4aa9f606b77ef",
+    "zh:764b7adadc3e58b9da84ea5954e2110d2c37797fea1b78b3a555fb76fbdd3c32",
+    "zh:911e48ca13fbb9d1eaf1ea9f8aa6de36fc227be46ce252ab2a235993329b1f55",
+    "zh:92c8fb2a4cf45f23b69d0f94e2971d3267f2ce5bd0ca5640ccc4739f171b6994",
+    "zh:96f505bd6c47cb2626728bdd6e0099e201b2c164989cbc1eb56bc6c21d0da054",
+    "zh:9ca10508c873243d6c30b9e9ad5ad61abd7e7ff462df56dcb650709b7f447585",
+    "zh:a90441436a5e5422c800fff85f57a70f7797775a3618188cba09dd11ac7e71af",
+    "zh:ad7a7d0729b292547b9d3c1c717f708aed2a0da107acaf62947dd4695beda07b",
+    "zh:c782ac728f3eae2111e2e11c825374e10285ebe9c7a063425474725ee4152fae",
+    "zh:cb3083b0c90eacd4c68f0758caceeb5c8780ad9e03dab7b6cadf786231087de9",
+    "zh:f2a2740af70455482ad7663924f944f5cce9a315929ccfcb20d8a0f9baa5187b",
+    "zh:f2a7eb18fb674a831b4b7fb2731ea26add938a592e536b072c2822ca6f5e430d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.33.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:scbW5Az1H4JRaho9R2tIzoZ1L3Y4L/tpRe9N2GjNxYA=",
+    "zh:10620bf55734d05701852dbbd55aa151860cbaf672001222c29ee93ec02d062e",
+    "zh:1ca1a3829a1fdbbce17a540d2be63b1529e46debdb8dbf0057facc992110ff38",
+    "zh:5f3a1b7b1feeafd4d4677b3936a1f6a66a02bf9844b6949e876ee64d0573a73a",
+    "zh:63c513a92a4842c53adbcd0103646e6828ce412f5a66efafaa0c79bc0dbe95de",
+    "zh:862812a0185d3467eae29f8923eebcecdcd50f9d1f0ec543004eaea96105ddc9",
+    "zh:9bf2df9ece0ade7c3fd57f0d164fb5c05211adfbb11315cf78d637bdb21c33cf",
+    "zh:9c378b72733dbe51ed81c81bb2c1902668d8f833d0d352d5fc2201571cffc6fe",
+    "zh:c17f96906e616b8e78c106884cf1c6621a5bdf69026f5debbddcc4b11af7b62c",
+    "zh:c410df582884bb3b8bc08a27b223783a541f4bd8223d025918545ae5435dcb10",
+    "zh:e68d159165213cd7f9c24a3d12a2141879126d6253f58587bb88de648fc6fbc9",
+    "zh:f13d4e191bb36979c3d9a40d8e18119743e8951bcb6fb7c456c0d94ea548f574",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.33.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:9dUFuu5MwZmZlGtyRIznN4Ih389eQC9YBSvgHn+Hnc0=",
+    "zh:0c2a87d4fc6cb4bdce514e02ac41f72b0a0b5c51aaf6ad2e13898344ad08e467",
+    "zh:35b1cb96957257a46384e311a547b3ad7de61eb80f677120d48bd11173a2d1bf",
+    "zh:4ea15b3db08eebd6f282e3a0257952c62aa2909a2c3e4b7c645023fcd9badbc7",
+    "zh:5d0e09e59234342c66b7ab8fe49cceb648f957dc26e39c9131cfa4f7fde17e70",
+    "zh:a2b950ec3b6507bd4c65b88e1c903bbe29cdba8f85bb55f868ca6e95f8088102",
+    "zh:aabfe4f9ae83766dbdc7a1d40d5ca8d23438c7bb2d681dc05bfdd5a76337c4fb",
+    "zh:bcee279a86480539f2204e4e5f5ed979d746f8bf27138791d3350cfd74897a26",
+    "zh:bd017406553a081f826215a5126faa82d26509af83a84a8cdcb2a1629546f255",
+    "zh:d752adcf17b3f33955495bf6d361904135236d968a6a3c99db5b742e8d6a725a",
+    "zh:ef1b88f7f5784805273fd2ec7125d7cc900a4c1e1f4192f453680a4a617f8e61",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f805d7eccbfefdb0967792be4232863e11eea51a0f921cb5426ff0282005390a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = ">= 3.6.0"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/iac/gcp/vpc.tf
+++ b/iac/gcp/vpc.tf
@@ -95,10 +95,9 @@ resource "google_vpc_access_connector" "connector" {
   subnet {
     name = google_compute_subnetwork.connector.name
   }
-  machine_type   = "e2-micro"
-  min_instances  = 2
-  max_instances  = 3
-  max_throughput = 300
+  machine_type  = "e2-micro"
+  min_instances = 2
+  max_instances = 3
 
   depends_on = [google_project_service.services]
 }


### PR DESCRIPTION
## Summary

- `google_vpc_access_connector` で `min/max_throughput` と `min/max_instances` は排他のため、新しい instances ベースに統一
- `terraform plan` 実行時の `Conflicting configuration arguments` エラーを解消

## エラー内容

\`\`\`
Error: Conflicting configuration arguments
  with google_vpc_access_connector.connector,
  on vpc.tf line 100, in resource "google_vpc_access_connector" "connector":
  100:   max_instances  = 3

"max_instances": conflicts with max_throughput
\`\`\`

## Test plan

- [ ] `iac/gcp/` で `terraform plan` がエラーなく完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)