### PR TITLE
fix(gcp): API 伝播待ち / Cloud SQL edition / Cloud Build 条件作成

### DIFF
--- a/iac/gcp/cloud_armor.tf
+++ b/iac/gcp/cloud_armor.tf
@@ -18,6 +18,8 @@ resource "google_compute_security_policy" "edge" {
   description = "Edge WAF policy for ${var.app-name}-${var.environment}"
   type        = "CLOUD_ARMOR"
 
+  depends_on = [time_sleep.wait_for_apis]
+
   # Adaptive Protection: ML ベースの異常検知 (AWS WAF にはない GCP 独自機能)
   adaptive_protection_config {
     layer_7_ddos_defense_config {

--- a/iac/gcp/cloud_build_backend.tf
+++ b/iac/gcp/cloud_build_backend.tf
@@ -94,14 +94,16 @@ resource "google_clouddeploy_delivery_pipeline" "backend" {
 
 # Cloud Build トリガー: main push + backend/** 変更で発火
 # Build phase で docker build → AR push、その後 gcloud deploy releases create でデプロイ
+# Cloud Build GitHub Connection が未設定の場合はトリガー自体を作成しない
 resource "google_cloudbuild_trigger" "backend" {
+  count           = var.cloudbuild-github-connection == "" ? 0 : 1
   name            = "${var.app-name}-${var.environment}-backend"
   location        = var.gcp-region
   service_account = google_service_account.cloudbuild_backend.id
   included_files  = ["${var.backend-src-root}/**"]
 
   repository_event_config {
-    repository = var.cloudbuild-github-connection == "" ? null : "${var.cloudbuild-github-connection}/repositories/${replace(var.github-repository-name, "/", "-")}"
+    repository = "${var.cloudbuild-github-connection}/repositories/${replace(var.github-repository-name, "/", "-")}"
 
     push {
       branch = "^${var.target-branch}$"

--- a/iac/gcp/cloud_build_frontend.tf
+++ b/iac/gcp/cloud_build_frontend.tf
@@ -32,14 +32,16 @@ resource "google_project_iam_member" "cb_frontend_logwriter" {
 }
 
 # Cloud Build トリガー: main push + frontend/** 変更で発火
+# Cloud Build GitHub Connection が未設定の場合はトリガー自体を作成しない
 resource "google_cloudbuild_trigger" "frontend" {
+  count           = var.cloudbuild-github-connection == "" ? 0 : 1
   name            = "${var.app-name}-${var.environment}-frontend"
   location        = var.gcp-region
   service_account = google_service_account.cloudbuild_frontend.id
   included_files  = ["${var.frontend-src-root}/**"]
 
   repository_event_config {
-    repository = var.cloudbuild-github-connection == "" ? null : "${var.cloudbuild-github-connection}/repositories/${replace(var.github-repository-name, "/", "-")}"
+    repository = "${var.cloudbuild-github-connection}/repositories/${replace(var.github-repository-name, "/", "-")}"
 
     push {
       branch = "^${var.target-branch}$"

--- a/iac/gcp/cloud_sql.tf
+++ b/iac/gcp/cloud_sql.tf
@@ -21,6 +21,9 @@ resource "google_sql_database_instance" "main" {
 
   settings {
     tier              = var.db-tier
+    # 新規プロジェクトでは ENTERPRISE_PLUS がデフォルトになり db-custom-* tier が使えないため
+    # 明示的に ENTERPRISE edition を指定 (Aurora Serverless v2 と同等の従来 tier 体系)
+    edition           = "ENTERPRISE"
     availability_type = "ZONAL"
     disk_type         = "PD_SSD"
     disk_size         = 10

--- a/iac/gcp/cloud_storage.tf
+++ b/iac/gcp/cloud_storage.tf
@@ -1,12 +1,19 @@
-# 静的Webアセット配信用 Cloud Storage バケット (LB Backend Bucket 経由でのみ公開)
+# 静的Webアセット配信用 Cloud Storage バケット (Cloud CDN 経由で配信)
 # AWS の S3 バケット (web) 相当
+#
+# 注: Backend Bucket + Cloud CDN で公開する場合の標準パターンとして
+# allUsers に objectViewer を付与し、public_access_prevention を inherited にする。
+# cloud-cdn-fill サービスエージェント (オンデマンド作成) を待つ方式は初回 apply で
+# 競合しやすいため、本テンプレートでは公開バケットパターンを採用。
+# (LB 経由でも直接 storage.googleapis.com 経由でも同じ静的アセットが配信されるだけで
+#  実質的な情報漏洩リスクはない)
 resource "google_storage_bucket" "web" {
   name                        = "${var.app-name}-${var.environment}-web-${random_string.suffix.result}"
   location                    = var.gcp-region
   storage_class               = "STANDARD"
   force_destroy               = true
   uniform_bucket_level_access = true
-  public_access_prevention    = "enforced"
+  public_access_prevention    = "inherited"
 
   # SPA ルーティング: 存在しないパスは index.html を返す
   # AWS CloudFront の custom_error_response (403 → /index.html) と同等の挙動を実現
@@ -30,12 +37,10 @@ resource "google_storage_bucket" "web" {
   }
 }
 
-# Cloud CDN の LB がバケットを読むためのサービスアカウントに objectViewer を付与
-# (Backend Bucket は IAM 経由で参照するため、バケット ACL は不要)
-# 注: GCS Backend Bucket は自動的に Cloud CDN サービスアカウントからアクセスされる。
-# バケットが uniform_bucket_level_access の場合、明示的に Storage Object Viewer を付与する。
-resource "google_storage_bucket_iam_member" "web_cdn_viewer" {
+# allUsers に objectViewer を付与してバケット内容を公開読みにする
+# (Cloud CDN backend bucket + 静的アセット配信の標準パターン)
+resource "google_storage_bucket_iam_member" "web_public_viewer" {
   bucket = google_storage_bucket.web.name
   role   = "roles/storage.objectViewer"
-  member = "serviceAccount:service-${data.google_project.self.number}@cloud-cdn-fill.iam.gserviceaccount.com"
+  member = "allUsers"
 }

--- a/iac/gcp/load_balancer.tf
+++ b/iac/gcp/load_balancer.tf
@@ -22,6 +22,8 @@
 # グローバル静的 IP: LB のフロントエンド IP
 resource "google_compute_global_address" "lb_ip" {
   name = "${var.app-name}-${var.environment}-lb-ip"
+
+  depends_on = [time_sleep.wait_for_apis]
 }
 
 # Serverless NEG: Cloud Run サービスを LB のバックエンドとして公開する
@@ -193,6 +195,8 @@ resource "google_compute_url_map" "https_redirect" {
     redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
     strip_query            = false
   }
+
+  depends_on = [time_sleep.wait_for_apis]
 }
 
 # Google マネージド SSL 証明書

--- a/iac/gcp/monitoring_alerts.tf
+++ b/iac/gcp/monitoring_alerts.tf
@@ -47,10 +47,12 @@ resource "google_monitoring_notification_channel" "pubsub" {
 }
 
 # Cloud Monitoring が Pub/Sub に publish するための IAM 付与
+# service identity (vpc.tf で google_project_service_identity.monitoring) を介して
+# SA を先回り作成しておくことで、初回 apply 時の "SA does not exist" エラーを回避
 resource "google_pubsub_topic_iam_member" "monitoring_publisher" {
   topic  = google_pubsub_topic.alarms.id
   role   = "roles/pubsub.publisher"
-  member = "serviceAccount:service-${data.google_project.self.number}@gcp-sa-monitoring-notification.iam.gserviceaccount.com"
+  member = "serviceAccount:${google_project_service_identity.monitoring.email}"
 }
 
 # Email 通知チャネル (alert-notification-emails が設定されている場合のみ)

--- a/iac/gcp/provider.tf
+++ b/iac/gcp/provider.tf
@@ -38,6 +38,10 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.6.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.10.0"
+    }
   }
 }
 

--- a/iac/gcp/vpc.tf
+++ b/iac/gcp/vpc.tf
@@ -27,6 +27,34 @@ resource "google_project_service" "services" {
   disable_on_destroy         = false
 }
 
+# API 有効化の伝播待ち
+# google_project_service の create が成功した直後にも、依存サービス
+# (compute.googleapis.com 等) の有効化が GCP 全体に伝播するまで 30-120 秒かかる。
+# この sleep を挟まないと "API not used / disabled" エラーで初回 apply が失敗する。
+resource "time_sleep" "wait_for_apis" {
+  depends_on      = [google_project_service.services]
+  create_duration = "60s"
+}
+
+# Cloud CDN の cache fill サービスエージェント SA を先に作成
+# (Backend Bucket への IAM 付与より前にこの SA を存在させる必要がある)
+resource "google_project_service_identity" "compute" {
+  provider = google-beta
+  project  = var.gcp-project-id
+  service  = "compute.googleapis.com"
+
+  depends_on = [time_sleep.wait_for_apis]
+}
+
+# Cloud Monitoring の通知用 SA を先に作成
+resource "google_project_service_identity" "monitoring" {
+  provider = google-beta
+  project  = var.gcp-project-id
+  service  = "monitoring.googleapis.com"
+
+  depends_on = [time_sleep.wait_for_apis]
+}
+
 # アプリ全体を収容する VPC (auto subnet を無効化して明示的にサブネットを定義)
 resource "google_compute_network" "vpc" {
   name                            = "${var.app-name}-${var.environment}"
@@ -34,7 +62,7 @@ resource "google_compute_network" "vpc" {
   routing_mode                    = "REGIONAL"
   delete_default_routes_on_create = false
 
-  depends_on = [google_project_service.services]
+  depends_on = [time_sleep.wait_for_apis]
 }
 
 # プライマリサブネット: Bastion 等のリソース配置先
@@ -111,6 +139,8 @@ resource "google_compute_global_address" "psa_range" {
   prefix_length = tonumber(split("/", var.psa_range_cidr_block)[1])
   address       = split("/", var.psa_range_cidr_block)[0]
   network       = google_compute_network.vpc.id
+
+  depends_on = [time_sleep.wait_for_apis]
 }
 
 # Service Networking 接続: Cloud SQL 等のマネージドサービスを Private IP で使うためのピアリング


### PR DESCRIPTION
## Summary

初回 `terraform apply` で発生する複数のエラーをまとめて解消。

## 修正内容

### 1. Compute Engine API 伝播待ち

`google_project_service` が成功してもエラー `Compute Engine API has not been used in project ... or it is disabled` が出るケースに対応。`time_sleep.wait_for_apis` を 60s 挟み、依存する compute リソース (Cloud Armor / LB IP / URL Map / PSA range) に明示的な `depends_on` を追加。

### 2. Cloud SQL の Edition 指定

新規プロジェクトでは Cloud SQL のデフォルト edition が `ENTERPRISE_PLUS` になり、`db-custom-*` tier が使えない:

\`\`\`
Error: Invalid Tier (db-custom-1-3840) for (ENTERPRISE_PLUS) Edition.
Use a predefined Tier like db-perf-optimized-N-* instead.
\`\`\`

`edition = "ENTERPRISE"` を明示することで従来 tier (`db-custom-1-3840` 等) を維持。

### 3. Cloud Build トリガーの条件作成

`cloudbuild-github-connection = ""` の状態でトリガーを作成すると repository 名が malformed になる:

\`\`\`
Error: repository  is malformed: generic::invalid_argument: incorrectly formatted name:
\`\`\`

`count = var.cloudbuild-github-connection == "" ? 0 : 1` でトリガー自体を条件作成に変更。

### 4. Cloud CDN サービスエージェント問題

`service-PROJECT_NUMBER@cloud-cdn-fill.iam.gserviceaccount.com` はオンデマンド作成で `google_project_service_identity` で先回り作成できない。Cloud CDN 静的アセット配信の標準パターン (allUsers public viewer + `public_access_prevention = inherited`) に変更。

### 5. Monitoring 通知 SA の先回り作成

`google_project_service_identity` で `monitoring.googleapis.com` の SA を先に作成し、Pub/Sub IAM 付与時の `Service account ... does not exist` エラーを回避。

## 適用前

\`\`\`powershell
cd iac/gcp
terraform init   # time プロバイダ追加のため必須
terraform apply
\`\`\`

## Test plan

- [ ] `terraform init` で time プロバイダがインストールされる
- [ ] `terraform plan` がエラーなく完了する
- [ ] `terraform apply` が全リソース作成まで完了する
- [ ] Cloud SQL が ENTERPRISE edition で作成される
- [ ] Cloud Build トリガーは Connection 設定時のみ作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)