### PR TITLE
fix(gcp): フロントエンドデプロイ SA に storage.buckets.get を追加

### DIFF
--- a/iac/gcp/workload_identity.tf
+++ b/iac/gcp/workload_identity.tf
@@ -92,10 +92,19 @@ resource "google_service_account_iam_member" "github_actions_frontend_wif" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.environment/${var.github-environment}"
 }
 
-# GCS バケットへの書き込み権限
+# GCS バケットへの書き込み権限 (object 操作)
 resource "google_storage_bucket_iam_member" "github_actions_frontend_writer" {
   bucket = google_storage_bucket.web.name
   role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.github_actions_frontend.email}"
+}
+
+# バケットメタデータ参照権限
+# gcloud storage rsync は事前に GetBucket を呼ぶため storage.buckets.get が必要。
+# objectAdmin にはこの権限が含まれないため legacyBucketReader を併用する。
+resource "google_storage_bucket_iam_member" "github_actions_frontend_bucket_reader" {
+  bucket = google_storage_bucket.web.name
+  role   = "roles/storage.legacyBucketReader"
   member = "serviceAccount:${google_service_account.github_actions_frontend.email}"
 }
 


### PR DESCRIPTION
## Summary

GitHub Actions のフロントエンドデプロイ (deploy-frontend-gcp.yaml) が以下のエラーで失敗していたため、デプロイ SA にバケットメタデータ参照権限を追加。

\`\`\`
ERROR: (gcloud.storage.rsync) [...] does not have storage.buckets.get access to the Google Cloud Storage bucket.
Permission 'storage.buckets.get' denied on resource (or it may not exist).
\`\`\`

## 原因

\`gcloud storage rsync\` はバケット存在確認のため事前に \`storage.buckets.get\` を呼ぶ。
これまで付与していた \`roles/storage.objectAdmin\` には object 操作権限のみが含まれ、bucket 自体のメタデータ参照権限は含まれない。

## 修正

\`roles/storage.legacyBucketReader\` を追加 binding し、\`storage.buckets.get\` / \`storage.buckets.list\` を補完。objectAdmin と併用することで最小権限を維持。

## Test plan

- [ ] terraform apply で binding 追加を反映
- [ ] GitHub Actions の \"Deploy React to GCP Cloud Storage\" を再実行
- [ ] sync / cp / invalidate 全ステップが完走
- [ ] LB IP にアクセスして React SPA が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)