### PR TITLE
fix(gcp): GitHub Actions の WIF 認証を access_token モードに変更

### DIFF
--- a/.github/workflows/deploy-backend-gcp.yaml
+++ b/.github/workflows/deploy-backend-gcp.yaml
@@ -42,6 +42,9 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account:            ${{ secrets.GCP_BACKEND_SERVICE_ACCOUNT }}
+          # access_token モード: auth ステップ内で impersonation を実行し、SA access token (1h) を取得。
+          # gcloud は静的トークンを使うため、後続コマンドで impersonation refresh が走らなくなる。
+          token_format: access_token
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy-frontend-gcp.yaml
+++ b/.github/workflows/deploy-frontend-gcp.yaml
@@ -47,6 +47,9 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account:            ${{ secrets.GCP_FRONTEND_SERVICE_ACCOUNT }}
+          # access_token モード: auth ステップ内で impersonation を実行し、SA access token (1h) を取得。
+          # gcloud は静的トークンを使うため、後続コマンドで impersonation refresh が走らなくなる。
+          token_format: access_token
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## Summary

GitHub Actions の WIF 認証 (\`google-github-actions/auth@v2\`) に \`token_format: access_token\` を追加し、impersonation を auth ステップ内で完結させる。

## 問題

frontend デプロイ workflow が以下のエラーで失敗していた:

\`\`\`
ERROR: (gcloud.storage.rsync) There was a problem refreshing your current auth tokens:
('Unable to acquire impersonated credentials', '{... "iam.serviceAccounts.getAccessToken denied"...}')
\`\`\`

IAM binding (\`roles/iam.workloadIdentityUser\` on the deploy SA) は正しく設定されており、\`gcloud iam service-accounts get-iam-policy\` でも確認済み。

## 原因と修正

\`google-github-actions/auth@v2\` のデフォルト動作 (\`external_account\` 形式) では、gcloud が API 呼び出しのたびに OIDC → STS → impersonation の dance を再実行する。この refresh が \"impersonated_service_account\" 形式を経由するため、impersonation を行う主体が federated principal ではなく gcloud 自身のローカル ADC になり、権限不足エラーになっていた可能性がある。

\`token_format: access_token\` を指定することで:

- auth ステップ内で federated principal が impersonation を実行し、SA access token (1h TTL) を取得
- 後続の gcloud は静的トークンを使うだけになり、refresh-time の impersonation が走らなくなる
- impersonation 自体に問題があれば auth ステップで明確に失敗する (診断が楽)

## Test plan

- [ ] PR マージ後、Actions タブから \"Deploy React to GCP Cloud Storage\" を実行
- [ ] auth ステップが \"Created credentials file...\" + access_token 取得まで成功
- [ ] rsync / cp / invalidate 全ステップ完走
- [ ] backend workflow も同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)