### PR TITLE
fix(azure): フロントエンドデプロイで index.html を no-cache・アセットを長期キャッシュ化

### DIFF
--- a/.github/workflows/deploy-frontend-azure.yaml
+++ b/.github/workflows/deploy-frontend-azure.yaml
@@ -67,14 +67,33 @@ jobs:
         run: yarn run build
         working-directory: .${{ env.FRONTEND_WORKING_DIRECTORY }}
 
-      - name: Upload to Azure Blob Storage
+      - name: Upload assets to Azure Blob Storage (long cache)
+        # ハッシュ付きアセット (assets/*-<hash>.js / .css 等) は再ビルドで URL が変わるため
+        # ブラウザ・Front Door の双方で長期キャッシュ可。 index.html もここで一旦アップロードされるが、
+        # 次ステップで上書きして Cache-Control を no-cache に切り替える。
         run: |
           az storage blob upload-batch \
             --account-name ${{ env.FRONTEND_STORAGE_ACCOUNT_NAME }} \
             --auth-mode login \
             --overwrite \
             -d '$web' \
-            -s .${{ env.FRONTEND_WORKING_DIRECTORY }}/dist
+            -s .${{ env.FRONTEND_WORKING_DIRECTORY }}/dist \
+            --content-cache-control 'public, max-age=31536000, immutable'
+
+      - name: Overwrite index.html with no-cache
+        # SPA エントリポイントは再デプロイ時に常に最新を返す必要がある
+        # (古い index.html は古いハッシュ付きアセット URL を指しており、 新デプロイ後に 404 となるため)
+        # AWS の `aws s3 cp index.html --cache-control "no-store, no-cache"` /
+        # GCP の `gcloud storage cp index.html --cache-control='no-store, no-cache'` と同等
+        run: |
+          az storage blob upload \
+            --account-name ${{ env.FRONTEND_STORAGE_ACCOUNT_NAME }} \
+            --auth-mode login \
+            --overwrite \
+            -c '$web' \
+            -f .${{ env.FRONTEND_WORKING_DIRECTORY }}/dist/index.html \
+            -n index.html \
+            --content-cache-control 'no-store, no-cache'
 
       - name: Purge Front Door Cache
         run: |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,31 @@ GCP の Cloud Armor は Cloud LB のフロントエンドではなく **API の 
 
 dev/sandbox 用途では Standard、本番リリース時に Premium へ切り替える運用を想定しています。 upgrade 手順 (`sku_name` 変更 + `azurerm_cdn_frontdoor_firewall_policy` / `azurerm_cdn_frontdoor_security_policy` 追加) と Standard 採用理由の詳細は [Front Door の SKU 選択について (Azure)](./docs/azure-frontdoor-sku.md) を参照してください。
 
+## フロントエンドデプロイ時のキャッシュ戦略
+
+Vite ビルドが生成する `dist/` は 2 種類のファイルに分かれ、 それぞれ異なる `Cache-Control` でアップロードします。
+
+| ファイル種別 | 例 | Cache-Control |
+|---|---|---|
+| ハッシュ付きアセット | `assets/index-Abc123.js` / `assets/main-Xyz789.css` | `public, max-age=31536000, immutable` (1 年) |
+| エントリポイント | `index.html` | `no-store, no-cache` |
+
+`index.html` は新しいハッシュ付きアセット URL を指す唯一のファイルです。 キャッシュされて古い `index.html` が返ると、 中で参照されているアセット URL (`assets/index-<oldhash>.js`) は新デプロイ後の Storage には既に存在しないため **404 (白画面)** になります。 CDN 側のパージはユーザブラウザに残ったキャッシュには無力なため、 アップロード時の `Cache-Control` 付与が必須です。
+
+3 クラウドとも同じ戦略で、 デプロイ時に「アセット長期キャッシュ → index.html 単体上書き → CDN パージ」の順で実行します。
+
+| クラウド | アセット (長期キャッシュ) | index.html (no-cache) | CDN パージ |
+|---|---|---|---|
+| AWS | `aws s3 sync ./dist --exclude "index.html"` ([code-pipeline-frontend.tf](./iac/aws/code-pipeline-frontend.tf)) | `aws s3 cp ./dist/index.html --cache-control "no-store, no-cache"` | `aws cloudfront create-invalidation --paths "/*"` |
+| Azure | `az storage blob upload-batch --content-cache-control 'public, max-age=31536000, immutable'` ([deploy-frontend-azure.yaml](./.github/workflows/deploy-frontend-azure.yaml)) | `az storage blob upload --content-cache-control 'no-store, no-cache'` (index.html 単体を再アップロード) | `az afd endpoint purge --content-paths '/*'` |
+| GCP | `gcloud storage rsync --exclude='^index\.html$'` ([deploy-frontend-gcp.yaml](./.github/workflows/deploy-frontend-gcp.yaml)) | `gcloud storage cp --cache-control='no-store, no-cache'` | `gcloud compute url-maps invalidate-cdn-cache --path='/*'` |
+
+CDN 側でも保険を効かせています:
+
+- **AWS CloudFront**: `/index.html` 専用ビヘイビアで `Managed-CachingDisabled` を設定し、 オリジンの Cache-Control が抜けた場合でも CDN レベルで no-cache 動作 ([cloudfront.tf](./iac/aws/cloudfront.tf))
+- **GCP Cloud CDN**: バックエンドバケットのキャッシュモードを `USE_ORIGIN_HEADERS` にして GCS の Cache-Control をそのまま尊重 ([load_balancer.tf](./iac/gcp/load_balancer.tf))
+- **Azure Front Door**: 既定でオリジンの Cache-Control を尊重するため Storage 側の設定のみで成立
+
 ## セットアップ
 
 ### ローカル開発


### PR DESCRIPTION
## Summary

- Azure フロントエンドデプロイで `index.html` の `Cache-Control` が空だった問題を修正
- ハッシュ付きアセットは `public, max-age=31536000, immutable`、 `index.html` は `no-store, no-cache` を付与する 2 段階アップロードに変更
- これにより AWS (`code-pipeline-frontend.tf`) / GCP (`deploy-frontend-gcp.yaml`) と同等のキャッシュ戦略が 3 クラウドで揃う

## なぜ必要か

旧構成 (`az storage blob upload-batch` 1 回呼び出し) では、 `index.html` を含む全ファイルに `Cache-Control` が付かず、 ブラウザの heuristics で数時間〜数日キャッシュされる可能性があった。 古い `index.html` を引いたユーザは、 そこに書かれている古いハッシュ付きアセット URL (`assets/index-<oldhash>.js`) を取得しようとするが、 新デプロイ後の Storage には既に存在しないため **404 (白画面)** になる。

Front Door の `purge` は CDN 側だけを無効化するため、 既にユーザブラウザに残っているキャッシュには無力。

## Test plan

- [ ] `workflow_dispatch` で `deploy-frontend-azure.yaml` を実行し、 2 ステップとも成功すること
- [ ] デプロイ後、 ブラウザの DevTools で以下を確認:
  - [ ] `index.html` のレスポンスヘッダに `Cache-Control: no-store, no-cache` が含まれる
  - [ ] `assets/*-<hash>.js` のレスポンスヘッダに `Cache-Control: public, max-age=31536000, immutable` が含まれる
- [ ] 続けて再デプロイし、 旧 `index.html` がブラウザにキャッシュされず最新が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)