### PR TITLE
fix(gcp): backend_bucket の cdn_policy 永続差分 (perpetual diff) を解消

### DIFF
--- a/iac/gcp/load_balancer.tf
+++ b/iac/gcp/load_balancer.tf
@@ -74,10 +74,9 @@ resource "google_compute_backend_bucket" "frontend" {
     # USE_ORIGIN_HEADERS: GCS にアップロード時に設定した Cache-Control をそのまま尊重
     # index.html に Cache-Control: no-store, no-cache を付与してアップロードする運用で
     # AWS の Managed-CachingDisabled (index.html ビヘイビア) と同等の挙動を実現
-    cache_mode  = "USE_ORIGIN_HEADERS"
-    client_ttl  = 86400
-    default_ttl = 86400
-    max_ttl     = 31536000
+    # 注: USE_ORIGIN_HEADERS では client_ttl / default_ttl / max_ttl は GCP API 側で無視され
+    #     常に 0 が返るため指定しない (指定すると毎回 0→指定値 の永続差分が発生する)
+    cache_mode = "USE_ORIGIN_HEADERS"
 
     # negative_caching_policy で許可されるコード: [300, 301, 302, 307, 308, 404, 405, 410, 421, 451, 501]
     # 403 は許可リストに含まれないため除外 (該当する場合は notFoundPage 経由で 404 にフォールバック)


### PR DESCRIPTION
## Summary

`google_compute_backend_bucket.frontend` で `terraform apply` 後に再度 `terraform plan` を実行すると、 `cdn_policy` の `client_ttl` / `default_ttl` / `max_ttl` で毎回 `0 → 指定値` の差分が出続ける**永続差分 (perpetual diff)** を解消する。

> 注: 取り下げた #118 と同内容を最新 main から再作成した PR です。

## 原因

`cache_mode = "USE_ORIGIN_HEADERS"` のとき、 GCP API はこれら 3 つの TTL フィールドを受け付けても保存せず、 GET レスポンスでは常に `0` を返す。

そのため:
- HCL: `client_ttl = 86400` / `default_ttl = 86400` / `max_ttl = 31536000`
- API state: 全て `0`

の差分が永続的に検出され、 `apply` してもすぐ次の `plan` で同じ差分が再出現する。

```
~ cdn_policy {
    ~ client_ttl  = 0 -> 86400
    ~ default_ttl = 0 -> 86400
    ~ max_ttl     = 0 -> 31536000
}
```

これらの TTL は元から機能していなかったデッドコードだった。

## 変更内容

- `iac/gcp/load_balancer.tf` から `client_ttl` / `default_ttl` / `max_ttl` の 3 行を削除
- USE_ORIGIN_HEADERS では TTL 指定が無視される旨をコメントで明示 (将来の再追加を防ぐため)

## 挙動への影響

なし。 元から機能していなかったため、 GCS の `Cache-Control` ヘッダによるオリジン制御 (`index.html` no-cache / ハッシュ付きアセット長期キャッシュ) はそのまま維持される。

## Test plan
- [ ] `terraform apply` 実行で `cdn_policy` のみ in-place 更新 (TTL 3 フィールドが API state から消える)
- [x] その後 `terraform plan` を実行し **No changes** になることを確認
- [ ] フロントエンドの実 HTTP レスポンスで `Cache-Control` が GCS 設定値 (`no-store, no-cache` / `public, max-age=31536000, immutable`) のまま返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)