### PR TITLE
feat(iac): リモート state backend を 3 クラウドに導入 (#138)

### DIFF
--- a/iac/.gitignore
+++ b/iac/.gitignore
@@ -5,6 +5,12 @@
 *.tfstate
 *.tfstate.*
 
+# backend 部分設定の実値 (バケット名/アカウント ID 等を含む)。
+# サンプルの backend.hcl.example のみ追跡する。
+backend.hcl
+backend.*.hcl
+!backend.hcl.example
+
 # Crash log files
 crash.log
 crash.*.log

--- a/iac/aws/backend.hcl.example
+++ b/iac/aws/backend.hcl.example
@@ -1,0 +1,8 @@
+# terraform init -backend-config=backend.hcl 用のサンプル。
+# このファイルをコピーして backend.hcl を作成し、実値を埋める。
+# backend.hcl は gitignore 済み (バケット名にアカウント ID を含むため)。
+# 値は bootstrap/ の `terraform output backend_config_hint` で確認できる。
+
+bucket = "sandbox-aws-dev-tfstate-<AWS_ACCOUNT_ID>"
+key    = "aws/terraform.tfstate"
+region = "ap-northeast-1"

--- a/iac/aws/backend.tf
+++ b/iac/aws/backend.tf
@@ -1,0 +1,18 @@
+# リモート state backend (S3)
+#
+# bucket / key / region などの環境依存値は、ここには書かず init 時に
+# -backend-config で注入する (部分設定 / partial configuration)。
+#   - CI:     GitHub Actions vars/secrets から -backend-config="key=value" で渡す
+#   - ローカル: backend.hcl を作成し terraform init -backend-config=backend.hcl
+# 設定すべきキーの一覧は backend.hcl.example を参照。
+#
+# 初回のみ: bootstrap/ で state バケットを作成 → 本ディレクトリで
+#   terraform init -backend-config=backend.hcl -migrate-state
+# によりローカル state をリモートへ移行する。
+terraform {
+  backend "s3" {
+    # use_lockfile = true で DynamoDB 不要の S3 ネイティブロックを使用 (TF 1.10+)。
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/iac/aws/bootstrap/.terraform.lock.hcl
+++ b/iac/aws/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.47.0"
+  constraints = ">= 6.24.0"
+  hashes = [
+    "h1:78OvPoiPYyW1WXNrIlsJOrviOKnHG3nybUQCZjQuyUQ=",
+    "h1:SMrvLnQWj7IG/TqGJ92uNNY3CQMhJ8l2vgyx4JotpnY=",
+    "h1:cn19NQndVIksT44BCnFHnNak7f8EURsZmT5BNeDC5YE=",
+    "h1:hNQ0rraBEuBFoe6DRLumojqKK1XDUmbmnMb63kFcUgg=",
+    "h1:wLw15aMuMVgPS68hOj8B0IhJr9tMClHdpyIkucdNJ60=",
+    "zh:16379546c8b3ebcd6dfe6a5d6b69eb243202585fbd4786e1207bf97004b60799",
+    "zh:2ab74c8cd808d1206e4885cbe54433d33b63a257a2ff6b177f6e10b367fabb26",
+    "zh:2e5142d5b41ab2bf33e408c040c1540260508a5f2b3dedcda805749611d1c044",
+    "zh:5428f836b8184be2922652438784c275565e882cec732cc64ba6ed40cf1e4edb",
+    "zh:7927df3cf86cb67be4b0f397dc8d9ce4c7fc4d61d2bbcb091ea9420395f909c5",
+    "zh:915b94b53bbfc95ed7f1dcc353a8b20b54cabb362c2304d92bc45d04dc4d0802",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9df44c98ce7939cdad234358b1c4778d42f7f485fb14ff5e340b061b2f86ce40",
+    "zh:acb2c2f6f8de5361f3ee2f7fbeab9ca23cef05fc5559abb6d99124a979239359",
+    "zh:c1c7b63502380987b6fb51d7ea0c03fe01ec105170acfe0146b28d4eb6173a91",
+    "zh:cc50e06c2a9759b3a93442887276e8c8a5b1722fe1714e628f28a57938845e3f",
+    "zh:ccac3cfc441914df16ed9f1029fe047446702cd576061a8acc6e07a06be669b3",
+    "zh:cdd918479cd9dda1ff67b9d13129862b48db3f58085b318208fb55b4886e4153",
+    "zh:da8a6b187750b4fb373697d4cbb58a29ac8a689bfb842129146e1451b6d8a4f1",
+    "zh:de0f3b71225f44002db8230c7504ae7b4250124b32bc3bc99e08eff48f60f59e",
+  ]
+}

--- a/iac/aws/bootstrap/README.md
+++ b/iac/aws/bootstrap/README.md
@@ -1,0 +1,40 @@
+# AWS Terraform state backend ブートストラップ
+
+`iac/aws` の Terraform state を格納するリモート backend (S3 バケット) を作成する。
+リモート backend を作るための「土台」なので、このモジュール自身はローカル state で動く
+(`backend` ブロックを持たない)。**初回 1 回だけ手動適用する。**
+
+ロックは S3 ネイティブロックファイル (`use_lockfile = true`) を使うため DynamoDB は不要。
+
+## 作成されるもの
+
+- state 専用 S3 バケット `sandbox-aws-dev-tfstate-<AWS_ACCOUNT_ID>`
+  - バージョニング有効 / SSE-S3 暗号化 / パブリックアクセス全ブロック / HTTPS 強制
+
+## 手順
+
+### 1. state バケットを作成 (初回のみ)
+
+```bash
+cd iac/aws/bootstrap
+terraform init
+terraform apply
+terraform output backend_config_hint   # bucket / key / region を控える
+```
+
+### 2. 親 (iac/aws) のローカル state をリモートへ移行 (初回のみ)
+
+```bash
+cd iac/aws
+cp backend.hcl.example backend.hcl      # 1. の output の値で埋める
+terraform init -backend-config=backend.hcl -migrate-state
+```
+
+`-migrate-state` で既存のローカル `terraform.tfstate` が S3 へコピーされる。移行後は
+ローカルの `terraform.tfstate*` は不要 (gitignore 済み)。
+
+## 注意
+
+- このモジュールの state (`bootstrap/terraform.tfstate`) はローカルに残る。バケット定義は
+  ほぼ不変なので通常は再 apply 不要。チームで共有する場合は別途リモート化を検討する。
+- バケットは `force_destroy` を付けていない。誤削除防止のため、破棄が必要な場合は手動で空にする。

--- a/iac/aws/bootstrap/main.tf
+++ b/iac/aws/bootstrap/main.tf
@@ -1,0 +1,85 @@
+# Terraform state 専用 S3 バケット
+#
+# 既存のログ用バケット等とは分離し、state 専用に作成する (Issue #138)。
+# 名前は ${app}-${env}-tfstate-${アカウントID} でグローバル一意にする。
+# ロックは S3 ネイティブロック (backend 側 use_lockfile = true) を使うため
+# DynamoDB テーブルは不要。
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "${var.app-name}-${var.environment}-tfstate-${data.aws_caller_identity.self.account_id}"
+  tags   = {}
+}
+
+# パブリックアクセス全面ブロック (state には機密が含まれるため必須)
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket                  = aws_s3_bucket.tfstate.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# バージョニング有効化 (state 破損時のロールバック手段を確保)
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# サーバサイド暗号化 (SSE-S3 / AES256)
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# 古い state バージョンの肥大化を防ぐライフサイクル
+resource "aws_s3_bucket_lifecycle_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    id     = "expire-noncurrent-state"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# HTTPS 以外のアクセスを拒否 (転送中の暗号化を強制)
+resource "aws_s3_bucket_policy" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.tfstate.arn,
+          "${aws_s3_bucket.tfstate.arn}/*",
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      },
+    ]
+  })
+}

--- a/iac/aws/bootstrap/outputs.tf
+++ b/iac/aws/bootstrap/outputs.tf
@@ -1,0 +1,13 @@
+output "tfstate_bucket" {
+  value       = aws_s3_bucket.tfstate.id
+  description = "親 iac/aws の backend.hcl に設定する bucket 名"
+}
+
+output "backend_config_hint" {
+  description = "親 iac/aws で実行する terraform init -migrate-state 用の backend 設定値"
+  value = {
+    bucket = aws_s3_bucket.tfstate.id
+    key    = "aws/terraform.tfstate"
+    region = var.aws-region
+  }
+}

--- a/iac/aws/bootstrap/provider.tf
+++ b/iac/aws/bootstrap/provider.tf
@@ -1,0 +1,20 @@
+# Terraform state backend ブートストラップ (AWS)
+#
+# このモジュールは「リモート state backend 自体を作成する」ためのものなので、
+# 鶏卵問題を避けるためにローカル state で実行する (backend ブロックを持たない)。
+# ここで作った S3 バケットを、親 (iac/aws) の backend "s3" が利用する。
+#
+# 適用は初回 1 回のみ手動で行う (詳細は README.md を参照)。
+provider "aws" {
+  region = var.aws-region
+}
+
+terraform {
+  required_version = ">= 1.13.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.24.0"
+    }
+  }
+}

--- a/iac/aws/bootstrap/variables.tf
+++ b/iac/aws/bootstrap/variables.tf
@@ -1,0 +1,17 @@
+variable "aws-region" {
+  default     = "ap-northeast-1"
+  description = "state バケットを作成するリージョン (親 iac/aws と揃える)"
+}
+
+variable "app-name" {
+  default     = "sandbox-aws"
+  description = "リソース名プレフィックス (親 iac/aws と揃える)"
+}
+
+variable "environment" {
+  default     = "dev"
+  description = "環境名 (親 iac/aws と揃える)"
+}
+
+# 実行中の AWS アカウント ID (state バケット名のグローバル一意化に利用)
+data "aws_caller_identity" "self" {}

--- a/iac/azure/backend.hcl.example
+++ b/iac/azure/backend.hcl.example
@@ -1,0 +1,9 @@
+# terraform init -backend-config=backend.hcl 用のサンプル。
+# このファイルをコピーして backend.hcl を作成し、実値を埋める。
+# backend.hcl は gitignore 済み。
+# 値は bootstrap/ の `terraform output backend_config_hint` で確認できる。
+
+resource_group_name  = "sandbox-dev-tfstate-rg"
+storage_account_name = "sandboxdev<RANDOM>tfstate"
+container_name       = "tfstate"
+key                  = "azure/terraform.tfstate"

--- a/iac/azure/backend.tf
+++ b/iac/azure/backend.tf
@@ -1,0 +1,16 @@
+# リモート state backend (azurerm / Blob Storage)
+#
+# storage_account_name などの環境依存値はここには書かず init 時に
+# -backend-config で注入する (部分設定 / partial configuration)。
+#   - CI:     GitHub Actions vars から -backend-config="storage_account_name=..." で渡す
+#   - ローカル: backend.hcl を作成し terraform init -backend-config=backend.hcl
+# 設定すべきキーの一覧は backend.hcl.example を参照。
+#
+# 初回のみ: bootstrap/ で Storage Account を作成 → 本ディレクトリで
+#   terraform init -backend-config=backend.hcl -migrate-state
+# によりローカル state をリモートへ移行する。
+terraform {
+  backend "azurerm" {
+    # azurerm backend は Blob リースによるロックを内蔵するため追加設定は不要。
+  }
+}

--- a/iac/azure/bootstrap/.terraform.lock.hcl
+++ b/iac/azure/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.74.0"
+  constraints = ">= 4.30.0"
+  hashes = [
+    "h1:PBiXTNz3vQjxlmEEO4ZwaEPms8ztbtf+NIIUuyDgtwI=",
+    "h1:Zqy2w+Hfn5RrMkjbONtzPGVtzsOxETE4gK8M03u0cig=",
+    "h1:rBEtG2V9B8QDW3KIxHUho/eaieHs/s/tbb/e0bEbnQA=",
+    "h1:yvqCYq9U8R+ujUFUFM1lHLvJqd+s5iqFO5MqCiqoHFA=",
+    "h1:zTMbAZqXUEqhQNkj8Q1n3zvfqur4cXSY9HSrRbEGz08=",
+    "zh:004decccb53c332710894b890f3a5fd724aeeb440c32a8d337d6a2fe9f4427cc",
+    "zh:10ee232dfa76c987cbd226f81f825bbbe36786a8097fcb811ff655f2b471959c",
+    "zh:43ffac27efbbcc741ec6e0e96e0def151ddb04d7ce7fd0b67032dc4cdaa20e90",
+    "zh:459438a78b6cb43ba09e2c11832c6234848a08ab264dc2efe809db8b073057d6",
+    "zh:4f156cb69b8ed3d43b52fd90106d06609736019bc79faf6c1695aa942bbdade4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:921285f6e9beb02a7482bb8036e6b032255bc0c4aa61a11def63870c1ee10672",
+    "zh:994cf51bdc8aefa7e8a93474a322c9231df3512e85bc603c9295343ebc31228c",
+    "zh:9c6136ed2ae6cbbbfc57e74cdd7b83af9faea5ca3c7e3fa82877aca0b215fd27",
+    "zh:a0349f105af1882bf9d795a6fdac2fbe71f2e588ca6f4587b87de7b5423a0be8",
+    "zh:c7a91501928e23d5d8f088909aaa633a13d5f032fbc2043c6618305beb090058",
+    "zh:f11cb049e16a459f799c4f394ac20f8e9b3d0ef210cf56cb0850e0beffeaf4e1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = ">= 3.7.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "h1:lVDv+0AjDjrLfpmaJbWqUmIw/k3/AHXLc3N4m55SNdo=",
+    "h1:o0s5Mk9NXMP60nlheO1r0LsDGGratFb3oL0t7bD2QnM=",
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/iac/azure/bootstrap/README.md
+++ b/iac/azure/bootstrap/README.md
@@ -1,0 +1,38 @@
+# Azure Terraform state backend ブートストラップ
+
+`iac/azure` の Terraform state を格納するリモート backend (Storage Account + Blob コンテナ)
+を作成する。リモート backend を作るための「土台」なので、このモジュール自身はローカル state
+で動く (`backend` ブロックを持たない)。**初回 1 回だけ手動適用する。**
+
+azurerm backend は Blob のリース機構によるロックを内蔵するため、別途ロック資源は不要。
+
+## 作成されるもの
+
+- state 用リソースグループ `sandbox-dev-tfstate-rg`
+- state 用 Storage Account `sandboxdev<RANDOM>tfstate`
+  - Blob バージョニング有効 / TLS1.2 強制 / HTTPS 強制 / 公開禁止
+- Blob コンテナ `tfstate`
+
+## 手順
+
+### 1. state ストレージを作成 (初回のみ)
+
+```bash
+cd iac/azure/bootstrap
+terraform init
+terraform apply -var="azure-subscription-id=<YOUR_SUBSCRIPTION_ID>"
+terraform output backend_config_hint   # 各値を控える
+```
+
+### 2. 親 (iac/azure) のローカル state をリモートへ移行 (初回のみ)
+
+```bash
+cd iac/azure
+cp backend.hcl.example backend.hcl      # 1. の output の値で埋める
+terraform init -backend-config=backend.hcl -migrate-state
+```
+
+## 注意
+
+- このモジュールの state (`bootstrap/terraform.tfstate`) はローカルに残る。
+- Storage Account は誤削除防止のため、破棄が必要な場合は手動でコンテナを空にする。

--- a/iac/azure/bootstrap/main.tf
+++ b/iac/azure/bootstrap/main.tf
@@ -1,0 +1,50 @@
+# Terraform state 専用のリソースグループ / Storage Account / コンテナ
+#
+# 既存のログ用ストレージ等とは分離し、state 専用に作成する (Issue #138)。
+# azurerm backend は Blob のリース機構によるロックを内蔵するため別途ロック資源は不要。
+
+resource "azurerm_resource_group" "tfstate" {
+  name     = "${var.app-name}-${var.environment}-tfstate-rg"
+  location = var.location
+}
+
+# state 用 Storage Account
+# 名前は 3-24 文字・英数小文字のみ。${app}${env}${random}tfstate でグローバル一意化。
+resource "azurerm_storage_account" "tfstate" {
+  name                            = "${var.app-name}${var.environment}${random_string.random.result}tfstate"
+  resource_group_name             = azurerm_resource_group.tfstate.name
+  location                        = azurerm_resource_group.tfstate.location
+  account_kind                    = "StorageV2"
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  access_tier                     = "Hot"
+  https_traffic_only_enabled      = true
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+
+  # ネットワーク制限はあえて設定しない (default_action = Allow)。
+  # 理由: GitHub-hosted runner は IP が動的なため、ログ用ストレージのような
+  # default Deny + ip_rules 方式では CI から state Blob へ到達できない。
+  # 代わりに HTTPS 強制 / TLS1.2 / 公開 Blob 禁止で保護し、認証は AAD/RBAC に委ねる。
+  # (self-hosted runner や Private Endpoint を使う場合は別途ネットワーク制限を検討)
+
+  blob_properties {
+    # state 破損時のロールバック手段として Blob のバージョニングを有効化
+    versioning_enabled = true
+
+    delete_retention_policy {
+      days = 30
+    }
+
+    container_delete_retention_policy {
+      days = 30
+    }
+  }
+}
+
+# state を格納する Blob コンテナ
+resource "azurerm_storage_container" "tfstate" {
+  name                  = "tfstate"
+  storage_account_id    = azurerm_storage_account.tfstate.id
+  container_access_type = "private"
+}

--- a/iac/azure/bootstrap/outputs.tf
+++ b/iac/azure/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "tfstate_storage_account" {
+  value       = azurerm_storage_account.tfstate.name
+  description = "親 iac/azure の backend.hcl に設定する storage_account_name"
+}
+
+output "backend_config_hint" {
+  description = "親 iac/azure で実行する terraform init -migrate-state 用の backend 設定値"
+  value = {
+    resource_group_name  = azurerm_resource_group.tfstate.name
+    storage_account_name = azurerm_storage_account.tfstate.name
+    container_name       = azurerm_storage_container.tfstate.name
+    key                  = "azure/terraform.tfstate"
+  }
+}

--- a/iac/azure/bootstrap/provider.tf
+++ b/iac/azure/bootstrap/provider.tf
@@ -1,0 +1,23 @@
+# Terraform state backend ブートストラップ (Azure)
+#
+# リモート state backend (Storage Account + コンテナ) 自体を作成するモジュール。
+# 鶏卵問題を避けるためローカル state で実行する (backend ブロックを持たない)。
+# 適用は初回 1 回のみ手動で行う (詳細は README.md を参照)。
+provider "azurerm" {
+  subscription_id = var.azure-subscription-id
+  features {}
+}
+
+terraform {
+  required_version = ">= 1.13.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.30.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.7.0"
+    }
+  }
+}

--- a/iac/azure/bootstrap/variables.tf
+++ b/iac/azure/bootstrap/variables.tf
@@ -1,0 +1,28 @@
+variable "azure-subscription-id" {
+  description = "【環境変数で指定】Azure サブスクリプション ID"
+}
+
+variable "location" {
+  type        = string
+  default     = "japaneast"
+  description = "state ストレージを作成するリージョン (親 iac/azure と揃える)"
+}
+
+variable "app-name" {
+  default     = "sandbox"
+  description = "リソース名プレフィックス (親 iac/azure と揃える)"
+}
+
+variable "environment" {
+  default     = "dev"
+  description = "環境名 (親 iac/azure と揃える)"
+}
+
+# Storage Account 名 (3-24 文字・英数小文字) のグローバル一意化用サフィックス
+resource "random_string" "random" {
+  length  = 6
+  upper   = false
+  lower   = true
+  numeric = true
+  special = false
+}

--- a/iac/gcp/backend.hcl.example
+++ b/iac/gcp/backend.hcl.example
@@ -1,0 +1,7 @@
+# terraform init -backend-config=backend.hcl 用のサンプル。
+# このファイルをコピーして backend.hcl を作成し、実値を埋める。
+# backend.hcl は gitignore 済み。
+# 値は bootstrap/ の `terraform output backend_config_hint` で確認できる。
+
+bucket = "sandbox-gcp-dev-tfstate-<GCP_PROJECT_ID>"
+prefix = "gcp/terraform.tfstate"

--- a/iac/gcp/backend.tf
+++ b/iac/gcp/backend.tf
@@ -1,0 +1,16 @@
+# リモート state backend (GCS)
+#
+# bucket などの環境依存値はここには書かず init 時に -backend-config で注入する
+# (部分設定 / partial configuration)。
+#   - CI:     GitHub Actions vars から -backend-config="bucket=..." で渡す
+#   - ローカル: backend.hcl を作成し terraform init -backend-config=backend.hcl
+# 設定すべきキーの一覧は backend.hcl.example を参照。
+#
+# 初回のみ: bootstrap/ で state バケットを作成 → 本ディレクトリで
+#   terraform init -backend-config=backend.hcl -migrate-state
+# によりローカル state をリモートへ移行する。
+terraform {
+  backend "gcs" {
+    # GCS backend はロックを内蔵するため追加設定は不要。
+  }
+}

--- a/iac/gcp/bootstrap/.terraform.lock.hcl
+++ b/iac/gcp/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.34.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:9QgBib/ID/c8aDjHibC+ZowRVjb8+jP72cDoas+SpBc=",
+    "h1:EaKQXM9bnoIh62mTGdjYBq6L2g5a7+jeVia/4XirzDE=",
+    "h1:i4IKZaHiILB4RChYsNAzLVjO/N4wk9iWmIQBhUsl8mw=",
+    "h1:m6b6Jpu4IhrvJ47o+JpRY3FNNiPzHW3ZiWiqyZClpYE=",
+    "h1:nOb+xcCmXZvjTInt0t4kYusGliT8XeLlu87mFuAvVyI=",
+    "zh:0d824f222454358a9686ead2b75059777dcfd8006ed929c514ba3454d2cd91ef",
+    "zh:3e59be6923aeef1669c122711f62f9d01880308dfe08fc2817807309be46e417",
+    "zh:809458bac1ea6f372934d28295ecacffd0cd5b31df117b9bbeed2b91b0cd6b98",
+    "zh:ac7178ed164abfbb058e4439aaff7dd1b06f56194440c46a89c0915aef39a35a",
+    "zh:b4bef4c098a7223a7d56c33324f03fafe91eee8f5a2874bf64a6d3e87fc46613",
+    "zh:bf659617d992c93aa02cf909fa940e21f8b90e662876d38aa8cdb27eac857adc",
+    "zh:cbfa1b666caf1f4497ef95b9beff7ba1911ee042e6c0a3f19478b5ff450fb507",
+    "zh:dcacfa747673ee2cf0d6b84d5f155ab0702210146d76402ecef719a1a8c16c1e",
+    "zh:f15751387ef9844c91f2e37e82e8693758a4f7802defb1543a55713a62306875",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7009e2aa90b8637ffd6727ffb4358100389903c3510e4899f8ed6020c0ebb9e",
+    "zh:fcfa7e41fcaf19ee809d70d45222ce0e87782bac3515b5ca5ea4f8209d86cd04",
+  ]
+}

--- a/iac/gcp/bootstrap/README.md
+++ b/iac/gcp/bootstrap/README.md
@@ -1,0 +1,36 @@
+# GCP Terraform state backend ブートストラップ
+
+`iac/gcp` の Terraform state を格納するリモート backend (GCS バケット) を作成する。
+リモート backend を作るための「土台」なので、このモジュール自身はローカル state で動く
+(`backend` ブロックを持たない)。**初回 1 回だけ手動適用する。**
+
+GCS backend はオブジェクトの世代管理によるロックを内蔵するため、別途ロック資源は不要。
+
+## 作成されるもの
+
+- state 専用 GCS バケット `sandbox-gcp-dev-tfstate-<GCP_PROJECT_ID>`
+  - バージョニング有効 / 一様バケットレベルアクセス / 公開禁止 (enforced)
+
+## 手順
+
+### 1. state バケットを作成 (初回のみ)
+
+```bash
+cd iac/gcp/bootstrap
+terraform init
+terraform apply -var="gcp-project-id=<YOUR_PROJECT_ID>"
+terraform output backend_config_hint   # bucket / prefix を控える
+```
+
+### 2. 親 (iac/gcp) のローカル state をリモートへ移行 (初回のみ)
+
+```bash
+cd iac/gcp
+cp backend.hcl.example backend.hcl      # 1. の output の値で埋める
+terraform init -backend-config=backend.hcl -migrate-state
+```
+
+## 注意
+
+- このモジュールの state (`bootstrap/terraform.tfstate`) はローカルに残る。
+- バケットは `force_destroy = false`。破棄が必要な場合は手動でオブジェクトを空にする。

--- a/iac/gcp/bootstrap/main.tf
+++ b/iac/gcp/bootstrap/main.tf
@@ -1,0 +1,34 @@
+# Terraform state 専用 GCS バケット
+#
+# 既存のログ用バケット等とは分離し、state 専用に作成する (Issue #138)。
+# GCS backend はオブジェクトの世代管理によるロックを内蔵するため別途ロック資源は不要。
+# 名前はプロジェクト ID を含めグローバル一意にする。
+resource "google_storage_bucket" "tfstate" {
+  name          = "${var.app-name}-${var.environment}-tfstate-${var.gcp-project-id}"
+  location      = var.gcp-region
+  storage_class = "STANDARD"
+
+  # state はチームの共有資産。誤削除防止のため force_destroy は無効。
+  force_destroy = false
+
+  # 一様バケットレベルアクセス (ACL を使わず IAM で一元管理)
+  uniform_bucket_level_access = true
+
+  # 公開を全面禁止 (state には機密が含まれる)
+  public_access_prevention = "enforced"
+
+  # state 破損時のロールバック手段としてオブジェクト世代管理を有効化
+  versioning {
+    enabled = true
+  }
+
+  # 古い世代の肥大化を防ぐ (10 世代を超えた古い state を削除)
+  lifecycle_rule {
+    condition {
+      num_newer_versions = 10
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}

--- a/iac/gcp/bootstrap/outputs.tf
+++ b/iac/gcp/bootstrap/outputs.tf
@@ -1,0 +1,12 @@
+output "tfstate_bucket" {
+  value       = google_storage_bucket.tfstate.name
+  description = "親 iac/gcp の backend.hcl に設定する bucket 名"
+}
+
+output "backend_config_hint" {
+  description = "親 iac/gcp で実行する terraform init -migrate-state 用の backend 設定値"
+  value = {
+    bucket = google_storage_bucket.tfstate.name
+    prefix = "gcp/terraform.tfstate"
+  }
+}

--- a/iac/gcp/bootstrap/provider.tf
+++ b/iac/gcp/bootstrap/provider.tf
@@ -1,0 +1,19 @@
+# Terraform state backend ブートストラップ (GCP)
+#
+# リモート state backend (GCS バケット) 自体を作成するモジュール。
+# 鶏卵問題を避けるためローカル state で実行する (backend ブロックを持たない)。
+# 適用は初回 1 回のみ手動で行う (詳細は README.md を参照)。
+provider "google" {
+  project = var.gcp-project-id
+  region  = var.gcp-region
+}
+
+terraform {
+  required_version = ">= 1.13.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0.0"
+    }
+  }
+}

--- a/iac/gcp/bootstrap/variables.tf
+++ b/iac/gcp/bootstrap/variables.tf
@@ -1,0 +1,18 @@
+variable "gcp-project-id" {
+  description = "【環境変数で指定】GCP プロジェクト ID"
+}
+
+variable "gcp-region" {
+  default     = "asia-northeast1"
+  description = "state バケットを作成するリージョン (親 iac/gcp と揃える)"
+}
+
+variable "app-name" {
+  default     = "sandbox-gcp"
+  description = "リソース名プレフィックス (親 iac/gcp と揃える)"
+}
+
+variable "environment" {
+  default     = "dev"
+  description = "環境名 (親 iac/gcp と揃える)"
+}


### PR DESCRIPTION
## 概要

#138 (Terraform plan/apply の CI/CD 化) の **最優先前提**であるリモート state backend を 3 クラウドに整備する。これは段階導入の **PR 1/4** で、コードのみ (実プロビジョニング・Secrets 設定・branch protection は別途人手で実施)。

## やったこと

各クラウドに「state backend を作るための土台」モジュール `bootstrap/` を追加。リモート backend 自身を作るため鶏卵問題を避けてローカル state で動き、**初回 1 回だけ手動適用**する。既存のログ用バケット/ストレージとは分離。

| クラウド | state ストア | ロック | ハードニング |
|---|---|---|---|
| AWS | 専用 S3 `…-tfstate-<account_id>` | S3 ネイティブ (`use_lockfile`、DynamoDB 不要) | versioning / SSE-S3 / public block 全部 / HTTPS 強制 |
| GCP | 専用 GCS `…-tfstate-<project_id>` | GCS 内蔵 | versioning / UBLA / 公開禁止(enforced) |
| Azure | 専用 RG + Storage Account + コンテナ | Blob リース内蔵 | Blob versioning / TLS1.2 / HTTPS 強制 / 公開 Blob 禁止 |

- 各親ディレクトリ (`iac/<cloud>`) に `backend.tf` を追加。bucket 等の環境依存値はコードに書かず、`init` 時に `-backend-config` で注入する**部分設定**方式 (`backend.hcl.example` 同梱)。
- `backend.hcl` (実値) は `iac/.gitignore` に追加。
- 移行手順 (`terraform init -migrate-state`) は各 `bootstrap/README.md` に記載。

## 適用手順 (マージ後に管理者が実施)

各クラウドで:
1. `cd iac/<cloud>/bootstrap && terraform init && terraform apply` → state ストア作成
2. `terraform output backend_config_hint` の値で `iac/<cloud>/backend.hcl` を作成
3. `cd iac/<cloud> && terraform init -backend-config=backend.hcl -migrate-state` → ローカル state を移行

## 検証

- 6 ディレクトリ全てで `terraform init -backend=false` + `terraform validate` 成功 (Terraform 1.13.5)。
- `terraform fmt -check -recursive` で新規ファイルの指摘なし。
- provider lock は linux/windows/darwin (amd64/arm64) を網羅。

## このあとの段階導入 (予定)

- PR 2/4: terraform 用 OIDC 認証 (AWS IAM OIDC + role / Azure federated credential / GCP terraform SA + WIF)
- PR 3/4: `ci-iac.yaml` に plan on PR + apply on merge + Slack 通知 + PR コメント (#136 の静的解析を前段ゲートに)
- PR 4/4: `docs/iac-spec.md` に CI/CD フロー・承認運用・必要な Secrets/Environments 一覧を追記

## 関連
- Closes は付けず #138 の一部。`Refs #138`