### PR TITLE
feat(iac): terraform plan/apply 用 OIDC 認証を 3 クラウドに追加 (#138)

### DIFF
--- a/docs/iac-cicd-setup.md
+++ b/docs/iac-cicd-setup.md
@@ -1,0 +1,183 @@
+# IaC CI/CD セットアップガイド (Terraform plan/apply)
+
+GitHub Actions で `terraform plan` (PR 時) / `terraform apply` (main マージ時) を動かすための
+初回セットアップ手順と、使用する GitHub Variables / Secrets の一覧。
+
+自動化 (ワークフロー本体) の仕様は `docs/iac-spec.md` の「6. CI/CD」節を参照。
+
+---
+
+## 前提
+
+- `iac/<cloud>/bootstrap/` を apply 済み (state backend が存在する)
+- `iac/<cloud>/github_actions_terraform.tf` (OIDC 認証リソース) を apply 済み
+- GitHub CLI (`gh`) インストール済み、`gh auth login` 済み
+- 対象リポジトリの Settings を編集できる Admin 権限
+
+---
+
+## GitHub Variables / Secrets 一覧
+
+### State Backend 変数 (`TF_STATE_*`)
+
+`iac/<cloud>/bootstrap/` を apply 後に登録する。`terraform output backend_config_hint` で確認できる。
+
+| 変数名 | 登録種別 | 説明 | 値の例 |
+|---|---|---|---|
+| `TF_STATE_BUCKET_AWS` | Variable | AWS state 用 S3 バケット名 | `sandbox-aws-dev-tfstate-123456789012` |
+| `TF_STATE_KEY_AWS` | Variable | S3 オブジェクトキー | `aws/terraform.tfstate` |
+| `TF_STATE_REGION_AWS` | Variable | state バケットのリージョン | `ap-northeast-1` |
+| `TF_STATE_BUCKET_GCP` | Variable | GCP state 用 GCS バケット名 | `sandbox-gcp-dev-tfstate-my-project-id` |
+| `TF_STATE_PREFIX_GCP` | Variable | GCS オブジェクトプレフィックス | `gcp/terraform.tfstate` |
+| `TF_STATE_RG_AZURE` | Variable | Azure state 用リソースグループ名 | `sandbox-dev-tfstate-rg` |
+| `TF_STATE_SA_AZURE` | Variable | Azure state 用 Storage Account 名 | `sandboxdevABCDEFtfstate` |
+| `TF_STATE_CONTAINER_AZURE` | Variable | Azure Blob コンテナ名 | `tfstate` |
+| `TF_STATE_KEY_AZURE` | Variable | Azure Blob キー | `azure/terraform.tfstate` |
+
+### OIDC 認証変数 (`TF_PLAN_*` / `TF_APPLY_*`)
+
+`iac/<cloud>/github_actions_terraform.tf` を apply 後に登録する。`terraform output github_actions_terraform` で確認できる。
+
+| 変数名 | 登録種別 | 説明 | 値の例 |
+|---|---|---|---|
+| `TF_PLAN_ROLE_ARN_AWS` | Variable | AWS plan 用 IAM Role ARN | `arn:aws:iam::123456789012:role/sandbox-aws-dev-terraform-plan` |
+| `TF_APPLY_ROLE_ARN_AWS` | Variable | AWS apply 用 IAM Role ARN | `arn:aws:iam::123456789012:role/sandbox-aws-dev-terraform-apply` |
+| `AWS_REGION` | Variable | AWS リージョン | `ap-northeast-1` |
+| `TF_PLAN_SA_GCP` | Variable | GCP plan 用 SA メール | `sandbox-gcp-dev-tf-plan@my-project.iam.gserviceaccount.com` |
+| `TF_APPLY_SA_GCP` | Variable | GCP apply 用 SA メール | `sandbox-gcp-dev-tf-apply@my-project.iam.gserviceaccount.com` |
+| `TF_WIF_PROVIDER_GCP` | Variable | GCP Workload Identity Provider リソース名 | `projects/123/locations/global/workloadIdentityPools/sandbox-gcp-dev-gh/providers/github` |
+| `TF_PLAN_CLIENT_ID_AZURE` | Variable | Azure plan 用 App Registration Client ID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `TF_APPLY_CLIENT_ID_AZURE` | Variable | Azure apply 用 App Registration Client ID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `AZURE_TENANT_ID` | **Secret** | Azure テナント ID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `AZURE_SUBSCRIPTION_ID` | **Secret** | Azure サブスクリプション ID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+
+> **Variable vs Secret の使い分け**
+> - Variable: 機密でない値。ワークフローログにも表示される。
+> - Secret: テナント ID・サブスクリプション ID など、漏洩するとなりすまし・フィッシングに悪用されうる値。
+
+---
+
+## セットアップ手順
+
+### 1. State Backend 変数を登録
+
+`iac/<cloud>/bootstrap/` を apply した後に実行する。
+
+```powershell
+# AWS
+cd iac/aws/bootstrap
+$out = terraform output -json backend_config_hint | ConvertFrom-Json
+gh variable set TF_STATE_BUCKET_AWS --body $out.bucket
+gh variable set TF_STATE_KEY_AWS    --body $out.key
+gh variable set TF_STATE_REGION_AWS --body $out.region
+
+# GCP
+cd iac/gcp/bootstrap
+$out = terraform output -json backend_config_hint | ConvertFrom-Json
+gh variable set TF_STATE_BUCKET_GCP --body $out.bucket
+gh variable set TF_STATE_PREFIX_GCP --body $out.prefix
+
+# Azure
+cd iac/azure/bootstrap
+$out = terraform output -json backend_config_hint | ConvertFrom-Json
+gh variable set TF_STATE_RG_AZURE        --body $out.resource_group_name
+gh variable set TF_STATE_SA_AZURE        --body $out.storage_account_name
+gh variable set TF_STATE_CONTAINER_AZURE --body $out.container_name
+gh variable set TF_STATE_KEY_AZURE       --body $out.key
+```
+
+### 2. OIDC 認証変数を登録
+
+`iac/<cloud>/github_actions_terraform.tf` を apply した後に実行する。
+
+```powershell
+# AWS
+cd iac/aws
+$out = terraform output -json github_actions_terraform | ConvertFrom-Json
+gh variable set TF_PLAN_ROLE_ARN_AWS  --body $out.TF_PLAN_ROLE_ARN_AWS
+gh variable set TF_APPLY_ROLE_ARN_AWS --body $out.TF_APPLY_ROLE_ARN_AWS
+gh variable set AWS_REGION            --body $out.AWS_REGION
+
+# GCP
+cd iac/gcp
+$out = terraform output -json github_actions_terraform | ConvertFrom-Json
+gh variable set TF_PLAN_SA_GCP      --body $out.TF_PLAN_SA_GCP
+gh variable set TF_APPLY_SA_GCP     --body $out.TF_APPLY_SA_GCP
+gh variable set TF_WIF_PROVIDER_GCP --body $out.TF_WIF_PROVIDER_GCP
+
+# Azure (sensitive output のため -json 経由で取得)
+cd iac/azure
+$raw = terraform output -json github_actions_terraform
+$out = $raw | ConvertFrom-Json
+gh variable set TF_PLAN_CLIENT_ID_AZURE  --body $out.TF_PLAN_CLIENT_ID_AZURE
+gh variable set TF_APPLY_CLIENT_ID_AZURE --body $out.TF_APPLY_CLIENT_ID_AZURE
+gh secret  set AZURE_TENANT_ID           --body $out.AZURE_TENANT_ID
+gh secret  set AZURE_SUBSCRIPTION_ID     --body $out.AZURE_SUBSCRIPTION_ID
+```
+
+### 3. GitHub Environment "iac-apply" を作成
+
+GitHub UI から操作する (`gh` CLI では Environment 作成ができないため)。
+
+1. リポジトリ → **Settings → Environments → New environment**
+2. 名前: **`iac-apply`**
+3. **Protection rules** で以下を設定:
+   - **Required reviewers**: apply 実行前に承認を必須化 (本番適用の誤操作防止)
+   - **Deployment branches**: `main` ブランチのみに限定
+
+> Environment を作成しないと apply ワークフローが OIDC 認証で失敗する。
+> (`token.actions.githubusercontent.com:sub` が `environment:iac-apply` にならないため)
+
+### 4. 登録内容を確認
+
+```powershell
+# Variables 一覧 (TF_* が揃っているか確認)
+gh variable list
+
+# Secrets 一覧
+gh secret list
+```
+
+---
+
+## 変数の仕組み
+
+ワークフロー (`.github/workflows/ci-iac.yaml`) は以下の流れで変数を利用する。
+
+```
+GitHub Variables/Secrets
+        │
+        ▼
+terraform init -backend-config   ← TF_STATE_* でどの state を参照するか決まる
+        │
+        ▼
+GitHub OIDC → AWS/GCP/Azure      ← TF_PLAN_*/TF_APPLY_* でどの権限でアクセスするか決まる
+        │
+        ▼
+terraform plan / apply
+```
+
+| フェーズ | 使う変数 | 役割 |
+|---|---|---|
+| `terraform init` | `TF_STATE_*` | -backend-config に渡し、リモート state の場所を指定 |
+| OIDC 認証 (plan) | `TF_PLAN_*` | PR ジョブが AssumeRoleWithWebIdentity / impersonate |
+| OIDC 認証 (apply) | `TF_APPLY_*` | iac-apply Environment 承認後のジョブのみ利用可 |
+
+### plan と apply で ID を分けている理由
+
+| ロール | 権限 | 信頼する OIDC subject |
+|---|---|---|
+| plan | 読み取り専用 (ReadOnly / viewer / Reader) | `pull_request` / `ref:refs/heads/main` |
+| apply | 全操作 (AdministratorAccess / owner / Owner) | `environment:iac-apply` のみ |
+
+apply ロールは GitHub Environment の **必須レビュアー承認** を経ないと取得できない subject
+(`environment:iac-apply`) からしか AssumeRole できない。これにより、`terraform apply`
+の実行には必ず人間の承認が必要になる。
+
+---
+
+## 関連ドキュメント
+
+- `docs/iac-spec.md` — IaC 全体仕様・CI/CD フロー詳細
+- `docs/azure-github-actions-setup.md` — Azure デプロイ用 OIDC の初回セットアップ
+- `iac/<cloud>/bootstrap/README.md` — 各クラウドの state backend 作成手順

--- a/iac/aws/github_actions_terraform.tf
+++ b/iac/aws/github_actions_terraform.tf
@@ -1,0 +1,132 @@
+# GitHub Actions 用 OIDC (terraform plan / apply)
+#
+# AWS が GitHub の OIDC トークンを信頼するための IAM OIDC Provider と、
+# plan (read) / apply (write) それぞれ専用の IAM Role を作成する。
+#
+# plan  ロール: PR や workflow_dispatch から利用。ReadOnlyAccess + state bucket 読み取り。
+# apply ロール: GitHub Environment "iac-apply" からのみ利用可能。AdministratorAccess。
+#              apply は必須レビュアー承認後にのみ実行されることで安全を担保する。
+#
+# 登録が必要な GitHub Variables / Secrets は terraform output github_actions_terraform で確認。
+
+# GitHub Actions の OIDC トークンを AWS で検証するための IAM Provider
+# リージョンを跨ぐグローバルリソースのため、同一 AWS アカウント内で 1 つだけ作成する。
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  # GitHub の OIDC エンドポイント TLS 証明書の thumbprint (2023 年以降 AWS 側が自動検証するため
+  # 実質的に使われないが、terraform provider の必須フィールドとして記入する)
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+}
+
+# ---------- plan 用 IAM Role ----------
+
+resource "aws_iam_role" "terraform_plan" {
+  name        = "${var.app-name}-${var.environment}-terraform-plan"
+  description = "GitHub Actions terraform plan 用 (ReadOnly)"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          # pull_request イベント (sub = repo:OWNER/REPO:pull_request) と
+          # workflow_dispatch (sub = repo:OWNER/REPO:ref:refs/heads/main) を許可する。
+          # apply 専用の "environment:iac-apply" は含まないため apply には使えない。
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:${var.github-repository-name}:pull_request",
+              "repo:${var.github-repository-name}:ref:refs/heads/main",
+            ]
+          }
+        }
+      },
+    ]
+  })
+}
+
+# ReadOnlyAccess: describe/list/get 系を網羅。terraform plan が必要な全 AWS API を概ねカバー。
+resource "aws_iam_role_policy_attachment" "terraform_plan_readonly" {
+  role       = aws_iam_role.terraform_plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# state バケットへの読み取りアクセス (ReadOnlyAccess には含まれる場合もあるが明示的に付与)
+resource "aws_iam_role_policy" "terraform_plan_state" {
+  name = "tfstate-read"
+  role = aws_iam_role.terraform_plan.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.app-name}-${var.environment}-tfstate-${data.aws_caller_identity.self.account_id}",
+          "arn:aws:s3:::${var.app-name}-${var.environment}-tfstate-${data.aws_caller_identity.self.account_id}/*",
+        ]
+      },
+    ]
+  })
+}
+
+# ---------- apply 用 IAM Role ----------
+
+resource "aws_iam_role" "terraform_apply" {
+  name        = "${var.app-name}-${var.environment}-terraform-apply"
+  description = "GitHub Actions terraform apply 用 (AdministratorAccess / iac-apply environment のみ)"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            # GitHub Environment "iac-apply" が active なジョブのみ AssumeRole できる。
+            # Environment に必須レビュアーを設定することで apply 前に承認を必須化する。
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github-repository-name}:environment:iac-apply"
+          }
+        }
+      },
+    ]
+  })
+}
+
+# terraform apply は IAM リソース (Role/Policy/OIDC Provider 等) を作成するため
+# AdministratorAccess が必要。
+resource "aws_iam_role_policy_attachment" "terraform_apply_admin" {
+  role       = aws_iam_role.terraform_apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# ---------- outputs ----------
+
+output "github_actions_terraform" {
+  description = "PR3 ワークフローに設定する GitHub Variables の値 (gh variable set で登録)"
+  value = {
+    TF_PLAN_ROLE_ARN_AWS  = aws_iam_role.terraform_plan.arn
+    TF_APPLY_ROLE_ARN_AWS = aws_iam_role.terraform_apply.arn
+    AWS_REGION            = data.aws_region.current.region
+  }
+}

--- a/iac/aws/github_actions_terraform.tf
+++ b/iac/aws/github_actions_terraform.tf
@@ -26,7 +26,7 @@ resource "aws_iam_openid_connect_provider" "github" {
 
 resource "aws_iam_role" "terraform_plan" {
   name        = "${var.app-name}-${var.environment}-terraform-plan"
-  description = "GitHub Actions terraform plan 用 (ReadOnly)"
+  description = "GitHub Actions terraform plan (ReadOnly)"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -89,7 +89,7 @@ resource "aws_iam_role_policy" "terraform_plan_state" {
 
 resource "aws_iam_role" "terraform_apply" {
   name        = "${var.app-name}-${var.environment}-terraform-apply"
-  description = "GitHub Actions terraform apply 用 (AdministratorAccess / iac-apply environment のみ)"
+  description = "GitHub Actions terraform apply (AdministratorAccess / iac-apply environment only)"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/iac/azure/github_actions_terraform.tf
+++ b/iac/azure/github_actions_terraform.tf
@@ -1,0 +1,101 @@
+# GitHub Actions 用 OIDC (terraform plan / apply)
+#
+# 既存のデプロイ用 SP (service-principal.tf) とは別に、terraform 専用の
+# App Registration / Service Principal を plan / apply それぞれ作成する。
+#
+# plan SP:  Reader ロール → PR や workflow_dispatch から利用可。
+# apply SP: Owner ロール → GitHub Environment "iac-apply" 承認後のみ利用可。
+#           Owner が必要な理由: terraform apply は azurerm_role_assignment を作成するため
+#           Microsoft.Authorization/roleAssignments/write 権限が必要。
+#
+# 各 SP には Federated Identity Credential を複数付与する:
+#   plan  → pull_request イベント用 + workflow_dispatch (refs/heads/main) 用
+#   apply → iac-apply Environment 用
+#
+# 登録が必要な GitHub Variables / Secrets は terraform output github_actions_terraform で確認。
+
+# ---------- plan 用 App Registration / SP ----------
+
+resource "azuread_application_registration" "terraform_plan" {
+  display_name     = "${var.app-name}-${var.environment}-terraform-plan"
+  description      = "GitHub Actions terraform plan 用 (Reader)"
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "terraform_plan" {
+  client_id = azuread_application_registration.terraform_plan.client_id
+}
+
+# PR イベント時の Federated Credential
+# subject = repo:OWNER/REPO:pull_request
+resource "azuread_application_federated_identity_credential" "terraform_plan_pr" {
+  application_id = azuread_application_registration.terraform_plan.id
+  display_name   = "${var.app-name}-${var.environment}-terraform-plan-pr"
+  description    = "terraform plan on pull_request"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:${var.github-repository-name}:pull_request"
+}
+
+# workflow_dispatch 時の Federated Credential (main ブランチから手動実行)
+# subject = repo:OWNER/REPO:ref:refs/heads/main
+resource "azuread_application_federated_identity_credential" "terraform_plan_dispatch" {
+  application_id = azuread_application_registration.terraform_plan.id
+  display_name   = "${var.app-name}-${var.environment}-terraform-plan-dispatch"
+  description    = "terraform plan on workflow_dispatch (main)"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:${var.github-repository-name}:ref:refs/heads/main"
+}
+
+# サブスクリプション全体への Reader ロール
+resource "azurerm_role_assignment" "terraform_plan_reader" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.terraform_plan.object_id
+}
+
+# ---------- apply 用 App Registration / SP ----------
+
+resource "azuread_application_registration" "terraform_apply" {
+  display_name     = "${var.app-name}-${var.environment}-terraform-apply"
+  description      = "GitHub Actions terraform apply 用 (Owner / iac-apply Environment のみ)"
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "terraform_apply" {
+  client_id = azuread_application_registration.terraform_apply.client_id
+}
+
+# GitHub Environment "iac-apply" が active なジョブのみ利用可能
+# subject = repo:OWNER/REPO:environment:iac-apply
+resource "azuread_application_federated_identity_credential" "terraform_apply" {
+  application_id = azuread_application_registration.terraform_apply.id
+  display_name   = "${var.app-name}-${var.environment}-terraform-apply"
+  description    = "terraform apply on iac-apply environment"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:${var.github-repository-name}:environment:iac-apply"
+}
+
+# サブスクリプション全体への Owner ロール
+# terraform apply は azurerm_role_assignment / azuread_* リソースを管理するため
+# Owner が必要 (Contributor では Microsoft.Authorization/roleAssignments/write が欠ける)。
+resource "azurerm_role_assignment" "terraform_apply_owner" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Owner"
+  principal_id         = azuread_service_principal.terraform_apply.object_id
+}
+
+# ---------- outputs ----------
+
+output "github_actions_terraform" {
+  description = "PR3 ワークフローに設定する GitHub Variables / Secrets の値 (gh variable/secret set で登録)"
+  sensitive   = true
+  value = {
+    TF_PLAN_CLIENT_ID_AZURE  = azuread_application_registration.terraform_plan.client_id
+    TF_APPLY_CLIENT_ID_AZURE = azuread_application_registration.terraform_apply.client_id
+    AZURE_TENANT_ID          = data.azurerm_client_config.current.tenant_id
+    AZURE_SUBSCRIPTION_ID    = data.azurerm_client_config.current.subscription_id
+  }
+}

--- a/iac/gcp/workload_identity_terraform.tf
+++ b/iac/gcp/workload_identity_terraform.tf
@@ -1,0 +1,87 @@
+# GitHub Actions 用 OIDC (terraform plan / apply)
+#
+# 既存の Workload Identity Pool / Provider (workload_identity.tf) を使い、
+# terraform plan (read) / apply (write) 専用のサービスアカウントを追加する。
+#
+# plan SA:  attribute.repository 条件 → PR や workflow_dispatch から利用可。
+#           roles/viewer (プロジェクト全体の読み取り) + state バケット読み取り。
+# apply SA: attribute.environment == "iac-apply" 条件 → GitHub Environment 承認後のみ利用可。
+#           roles/owner (terraform が IAM リソースを作成するため) + state バケット読み書き。
+#
+# 登録が必要な GitHub Variables / Secrets は terraform output github_actions_terraform で確認。
+
+# state バケットへの参照 (bootstrap/ で作成済み)
+# plan/apply SA に IAM バインディングを付与するために使用する。
+data "google_storage_bucket" "tfstate" {
+  name = "${var.app-name}-${var.environment}-tfstate-${var.gcp-project-id}"
+}
+
+# ---------- plan 用 SA ----------
+
+resource "google_service_account" "terraform_plan" {
+  account_id   = "${var.app-name}-${var.environment}-tf-plan"
+  display_name = "GitHub Actions Terraform Plan SA"
+}
+
+# plan SA は PR および workflow_dispatch (environment なし) から impersonate できる。
+# attribute.repository で対象リポジトリを限定する。
+resource "google_service_account_iam_member" "terraform_plan_wif" {
+  service_account_id = google_service_account.terraform_plan.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github-repository-name}"
+}
+
+# プロジェクト全体の読み取り (describe/list 系を網羅)
+resource "google_project_iam_member" "terraform_plan_viewer" {
+  project = var.gcp-project-id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.terraform_plan.email}"
+}
+
+# state バケットの読み取り
+resource "google_storage_bucket_iam_member" "terraform_plan_state_reader" {
+  bucket = data.google_storage_bucket.tfstate.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.terraform_plan.email}"
+}
+
+# ---------- apply 用 SA ----------
+
+resource "google_service_account" "terraform_apply" {
+  account_id   = "${var.app-name}-${var.environment}-tf-apply"
+  display_name = "GitHub Actions Terraform Apply SA"
+}
+
+# apply SA は GitHub Environment "iac-apply" が active なジョブのみ impersonate できる。
+# Environment に必須レビュアーを設定することで apply 前に承認を必須化する。
+resource "google_service_account_iam_member" "terraform_apply_wif" {
+  service_account_id = google_service_account.terraform_apply.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.environment/iac-apply"
+}
+
+# terraform apply は SA / WIF / IAM 等を作成するため roles/owner が必要。
+resource "google_project_iam_member" "terraform_apply_owner" {
+  project = var.gcp-project-id
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.terraform_apply.email}"
+}
+
+# state バケットの読み書き
+resource "google_storage_bucket_iam_member" "terraform_apply_state_admin" {
+  bucket = data.google_storage_bucket.tfstate.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.terraform_apply.email}"
+}
+
+# ---------- outputs ----------
+
+output "github_actions_terraform" {
+  description = "PR3 ワークフローに設定する GitHub Variables の値 (gh variable set で登録)"
+  value = {
+    TF_PLAN_SA_GCP  = google_service_account.terraform_plan.email
+    TF_APPLY_SA_GCP = google_service_account.terraform_apply.email
+    # WIF Provider は既存 output github_actions_secrets の GCP_WORKLOAD_IDENTITY_PROVIDER と同じ値
+    TF_WIF_PROVIDER_GCP = "${google_iam_workload_identity_pool.github.name}/providers/${google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id}"
+  }
+}


### PR DESCRIPTION
## 概要

#138 の段階導入 **PR 2/4** — terraform plan/apply それぞれ専用の OIDC 認証 ID を 3 クラウドに追加する。`plan=read / apply=write` で ID を分離し、apply は GitHub Environment `iac-apply` の必須レビュアー承認後のみ実行できる。

## 変更内容

| クラウド | ファイル | plan ID | apply ID |
|---|---|---|---|
| AWS | `github_actions_terraform.tf` | IAM Role (ReadOnlyAccess) | IAM Role (AdministratorAccess) |
| GCP | `workload_identity_terraform.tf` | SA (roles/viewer) | SA (roles/owner) |
| Azure | `github_actions_terraform.tf` | App Reg + SP (Reader) | App Reg + SP (Owner) |

### plan の trust 条件

| クラウド | 許可する subject |
|---|---|
| AWS | `repo:...:pull_request` / `repo:...:ref:refs/heads/main` |
| GCP | `attribute.repository == github-repository-name` |
| Azure | federated cred × 2: `pull_request` / `ref:refs/heads/main` |

### apply の trust 条件

全クラウド共通: `repo:...:environment:iac-apply` のみ。Environment に必須レビュアーを設定することで承認ゲートを実現する。

### 権限設計の補足

- **AWS apply: AdministratorAccess** — IAM Role/Policy/OIDC Provider を terraform が管理するため必要。
- **GCP apply: roles/owner** — `google_project_iam_member` 等 IAM 操作に必要。
- **Azure apply: Owner** — `azurerm_role_assignment` 作成に `Microsoft.Authorization/roleAssignments/write` が必要なため Contributor では不足。

## 適用手順 (マージ後に管理者が実施)

各クラウドで `terraform apply` 後に output を GitHub Variables/Secrets に登録:

```powershell
# AWS
cd iac/aws
$out = terraform output -json github_actions_terraform | ConvertFrom-Json
gh variable set TF_PLAN_ROLE_ARN_AWS  --body $out.TF_PLAN_ROLE_ARN_AWS
gh variable set TF_APPLY_ROLE_ARN_AWS --body $out.TF_APPLY_ROLE_ARN_AWS
gh variable set AWS_REGION            --body $out.AWS_REGION

# GCP
cd iac/gcp
$out = terraform output -json github_actions_terraform | ConvertFrom-Json
gh variable set TF_PLAN_SA_GCP      --body $out.TF_PLAN_SA_GCP
gh variable set TF_APPLY_SA_GCP     --body $out.TF_APPLY_SA_GCP
gh variable set TF_WIF_PROVIDER_GCP --body $out.TF_WIF_PROVIDER_GCP

# Azure (sensitive のため -json 経由)
cd iac/azure
$out = terraform output -json github_actions_terraform | ConvertFrom-Json | ForEach-Object { $_ }
gh variable set TF_PLAN_CLIENT_ID_AZURE  --body $out.TF_PLAN_CLIENT_ID_AZURE
gh variable set TF_APPLY_CLIENT_ID_AZURE --body $out.TF_APPLY_CLIENT_ID_AZURE
gh secret  set AZURE_TENANT_ID           --body $out.AZURE_TENANT_ID
gh secret  set AZURE_SUBSCRIPTION_ID     --body $out.AZURE_SUBSCRIPTION_ID
```

また GitHub UI で `Settings → Environments → New environment` から **`iac-apply`** を作成し、必須レビュアーを設定する。

## 検証

- 3 クラウド全てで `terraform validate` 成功、warning なし (Terraform 1.13.5)

## 関連
- Refs #138
- Depends on PR #170 (state backend) — マージ済み