### PR TITLE
fix(ci): plan PR コメントをサマリ行のみに変更 (アカウントID等を非表示)

### DIFF
--- a/.github/workflows/ci-iac.yaml
+++ b/.github/workflows/ci-iac.yaml
@@ -253,11 +253,9 @@ jobs:
             2>&1 | tee plan.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
           set -e
-          # plan 出力をサマリに追記 (GitHub Actions の Summary)
-          echo '### terraform plan — ${{ matrix.cloud }}' >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          tail -20 plan.txt >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # パブリックリポジトリのため Actions Summary にもフル出力は書かない。
+          # アカウント ID / ARN 等を含む詳細はローカルで確認すること。
+          # PR コメントへのサマリ行投稿は後続ステップで行う。
         env:
           ARM_CLIENT_ID: ${{ vars.TF_PLAN_CLIENT_ID_AZURE }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -433,12 +431,9 @@ jobs:
       - name: terraform plan
         working-directory: iac/${{ matrix.cloud }}
         run: |
+          # パブリックリポジトリのため plan フル出力は記録しない。
           terraform plan -out=tfplan -input=false -no-color \
             2>&1 | tee plan.txt
-          echo '### terraform plan (pre-apply) — ${{ matrix.cloud }}' >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          tail -20 plan.txt >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
         env:
           ARM_CLIENT_ID: ${{ vars.TF_APPLY_CLIENT_ID_AZURE }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ci-iac.yaml
+++ b/.github/workflows/ci-iac.yaml
@@ -267,8 +267,10 @@ jobs:
           TF_VAR_auth0_client_id: ${{ secrets.TF_VAR_AUTH0_CLIENT_ID }}
           TF_VAR_auth0_client_secret: ${{ secrets.TF_VAR_AUTH0_CLIENT_SECRET }}
 
-      # ── PR コメントに plan 結果を投稿 (更新/新規) ─────────────────────
-      - name: Post plan result to PR
+      # ── PR コメントに plan サマリのみ投稿 (更新/新規) ────────────────
+      # フル出力 (アカウント ID / ARN 等を含む) は PR コメントに載せず
+      # Actions Summary に留める。PR コメントには変更行数サマリと Run リンクのみ表示。
+      - name: Post plan summary to PR
         if: always()
         uses: actions/github-script@v7
         with:
@@ -277,28 +279,35 @@ jobs:
             const cloud = '${{ matrix.cloud }}';
             const outcome = '${{ steps.plan.outcome }}';
             const icon = outcome === 'success' ? '✅' : '❌';
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
 
-            let plan = '';
+            // plan 出力からサマリ行のみ抽出 (アカウント ID 等を含む行は表示しない)
+            // 例: "Plan: 3 to add, 1 to change, 0 to destroy."
+            //     "No changes. Your infrastructure matches the configuration."
+            let summary = '';
             try {
-              plan = fs.readFileSync(`iac/${cloud}/plan.txt`, 'utf8');
+              const text = fs.readFileSync(`iac/${cloud}/plan.txt`, 'utf8');
+              const match = text.match(/^(Plan: .+|No changes\..+)$/m);
+              if (match) {
+                summary = `\`${match[1]}\``;
+              } else if (outcome !== 'success') {
+                summary = 'plan が失敗しました。詳細は Actions Run を確認してください。';
+              } else {
+                summary = '(サマリが取得できませんでした)';
+              }
             } catch (_) {
-              plan = '(plan output not available)';
-            }
-            const MAX = 60000;
-            if (plan.length > MAX) {
-              plan = plan.slice(0, MAX) + '\n\n... (出力が長すぎるため省略。GitHub Actions の Summary で全文を確認してください)';
+              summary = '(plan output not available)';
             }
 
             const marker = `<!-- tf-plan-${cloud} -->`;
-            const body = `${marker}
-            ### ${icon} terraform plan — \`${cloud}\`
-
-            <details><summary>Plan output (クリックで展開)</summary>
-
-            \`\`\`
-            ${plan}
-            \`\`\`
-            </details>`;
+            const body = [
+              marker,
+              `### ${icon} terraform plan — \`${cloud}\``,
+              '',
+              summary,
+              '',
+              `> フル出力 (リソース差分の詳細) は [Actions Run](${runUrl}) の Summary タブを確認してください。`,
+            ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,


### PR DESCRIPTION
## 問題

terraform plan のフル出力を PR コメントに貼ると、AWS アカウント ID・ARN・IP アドレス等がリポジトリのアクセス権を持つ全員に見える状態になっていた。

## 修正

| 変更前 | 変更後 |
|---|---|
| PR コメントにフル plan 出力 (折りたたみ) | PR コメントはサマリ行のみ |
| アカウント ID / ARN 等が PR に記録される | 変更行数と Actions Run リンクのみ |

**PR コメント例 (修正後):**
```
✅ terraform plan — `aws`

`Plan: 3 to add, 1 to change, 0 to destroy.`

> フル出力は Actions Run の Summary タブを確認してください。
```

フル出力は GitHub Actions Summary に引き続き記録される (Actions 権限が必要なため一般公開されない)。

Refs #138