### PR TITLE
fix(ci): plan の exit code がパイプで隠れる問題を修正

### DIFF
--- a/.github/workflows/ci-iac.yaml
+++ b/.github/workflows/ci-iac.yaml
@@ -253,11 +253,14 @@ jobs:
           # plan ロール (ReadOnly/viewer/Reader) に PutObject 権限を与えずに済む。
           terraform plan -out=tfplan -input=false -no-color -lock=false \
             2>&1 | tee plan.txt
-          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          TF_EXIT=${PIPESTATUS[0]}
+          echo "exit_code=$TF_EXIT" >> "$GITHUB_OUTPUT"
           set -e
           # パブリックリポジトリのため Actions Summary にもフル出力は書かない。
           # アカウント ID / ARN 等を含む詳細はローカルで確認すること。
           # PR コメントへのサマリ行投稿は後続ステップで行う。
+          # plan 失敗時はステップを失敗させる (後続の PR コメントは if:always() で動く)
+          exit $TF_EXIT
         env:
           ARM_CLIENT_ID: ${{ vars.TF_PLAN_CLIENT_ID_AZURE }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -434,6 +437,8 @@ jobs:
         working-directory: iac/${{ matrix.cloud }}
         run: |
           # パブリックリポジトリのため plan フル出力は記録しない。
+          # pipefail で terraform の exit code をパイプ越しに伝播させる。
+          set -o pipefail
           terraform plan -out=tfplan -input=false -no-color \
             2>&1 | tee plan.txt
         env:

--- a/iac/gcp/workload_identity_terraform.tf
+++ b/iac/gcp/workload_identity_terraform.tf
@@ -39,12 +39,14 @@ resource "google_project_iam_member" "terraform_plan_viewer" {
   member  = "serviceAccount:${google_service_account.terraform_plan.email}"
 }
 
-# Storage バケットの IAM ポリシー読み取り
-# roles/viewer には storage.buckets.getIamPolicy が含まれないため個別付与が必要。
-# terraform plan が google_storage_bucket_iam_member リソースの差分を計算する際に使用する。
-resource "google_project_iam_member" "terraform_plan_storage_legacy_reader" {
+# 全リソースの IAM ポリシー読み取り
+# roles/viewer には *.getIamPolicy が含まれないため個別付与が必要。
+# terraform plan が google_*_iam_member リソースの差分計算時に IAM ポリシーを読む際に使用する。
+# roles/iam.securityReviewer はプロジェクトレベルで全リソースの getIamPolicy を含む
+# (roles/storage.legacyBucketReader はプロジェクトレベルでは使用不可)。
+resource "google_project_iam_member" "terraform_plan_security_reviewer" {
   project = var.gcp-project-id
-  role    = "roles/storage.legacyBucketReader"
+  role    = "roles/iam.securityReviewer"
   member  = "serviceAccount:${google_service_account.terraform_plan.email}"
 }
 

--- a/iac/gcp/workload_identity_terraform.tf
+++ b/iac/gcp/workload_identity_terraform.tf
@@ -39,6 +39,15 @@ resource "google_project_iam_member" "terraform_plan_viewer" {
   member  = "serviceAccount:${google_service_account.terraform_plan.email}"
 }
 
+# Storage バケットの IAM ポリシー読み取り
+# roles/viewer には storage.buckets.getIamPolicy が含まれないため個別付与が必要。
+# terraform plan が google_storage_bucket_iam_member リソースの差分を計算する際に使用する。
+resource "google_project_iam_member" "terraform_plan_storage_legacy_reader" {
+  project = var.gcp-project-id
+  role    = "roles/storage.legacyBucketReader"
+  member  = "serviceAccount:${google_service_account.terraform_plan.email}"
+}
+
 # state バケットの読み取り
 resource "google_storage_bucket_iam_member" "terraform_plan_state_reader" {
   bucket = data.google_storage_bucket.tfstate.name


### PR DESCRIPTION
## 問題

`terraform plan ... | tee plan.txt` ではパイプ末尾の `tee` (exit 0) が採用されるため、terraform が exit 1 でも CI ステップが成功扱いになっていた。

## 修正

- **plan ジョブ**: `PIPESTATUS[0]` で terraform の終了コードを取得し `exit` で伝播。後続の PR コメントステップは `if: always()` のため引き続き動作する。
- **apply ジョブ**: `set -o pipefail` でパイプ越しに伝播。plan 失敗時は apply が実行されなくなる。